### PR TITLE
[Feat] 버블 차트 레이아웃 구현

### DIFF
--- a/frontend/components/community/AutoComplete.tsx
+++ b/frontend/components/community/AutoComplete.tsx
@@ -8,11 +8,16 @@ import TrieSearchEngine from '../../utils/TrieSearchEngine';
 import AddCircleIcon from '@public/images/add-circle.svg';
 import styles from '@sass/components/community/AutoComplete.module.scss';
 import classnames from 'classnames/bind';
+import { KeywordData } from '../../types/types';
 const cx = classnames.bind(styles);
+
+interface AutoCompleteProps {
+  communityKeywordData: KeywordData[];
+}
 
 const searchEngine = new TrieSearchEngine();
 
-const AutoComplete = () => {
+const AutoComplete = ({ communityKeywordData }: AutoCompleteProps) => {
   const [searchKeyword, setSearchKeyword] = useState<string>('');
   const [searchResult, setSearchResult] = useState<string[]>(['']);
   const [isOpenDropdown, setIsOpenDropDown] = useState<boolean>(false);
@@ -32,23 +37,11 @@ const AutoComplete = () => {
   };
 
   useEffect(() => {
-    // TODO : 나중에는 서버에서 받아와야한다.
-    const mockWordList = [
-      { keyword: '가', count: 3 },
-      { keyword: '다', count: 3 },
-      { keyword: '나', count: 3 },
-      { keyword: '가나', count: 3 },
-      { keyword: '가다', count: 3 },
-      { keyword: '가나다', count: 2 },
-      { keyword: '가나라', count: 3 },
-      { keyword: '가나라마', count: 3 },
-    ];
-
-    mockWordList.forEach((word) => {
+    communityKeywordData.forEach((word) => {
       searchEngine.insert(word);
     });
 
-    setSearchResult(mockWordList.map(({ keyword }) => keyword));
+    setSearchResult(communityKeywordData.map(({ keyword }) => keyword));
   }, []);
 
   return (

--- a/frontend/components/community/KeywordAddModal.tsx
+++ b/frontend/components/community/KeywordAddModal.tsx
@@ -93,6 +93,7 @@ const KeywordAddModal = () => {
               />
               <button className={cx('keyword-add-button')}>추가하기</button>
             </form>
+            {/* TODO: 리팩토링때 추상화시켜서 공통으로 쓰기*/}
             {isOpenDropdown && (
               <ul className={cx('search-result-list')}>
                 {searchResult.map((word) => (
@@ -101,7 +102,6 @@ const KeywordAddModal = () => {
               </ul>
             )}
           </div>
-
           {/* 키워드 추천은 추가 섹션과 기능적으로 연관되어있다고 할 수 있을까? */}
           <KeywordAssociated />
         </section>

--- a/frontend/components/community/KeywordBubble.tsx
+++ b/frontend/components/community/KeywordBubble.tsx
@@ -1,0 +1,26 @@
+import { BubbleData } from '../../types/types';
+import styles from '@sass/components/community/KeywordBubble.module.scss';
+import classnames from 'classnames/bind';
+const cx = classnames.bind(styles);
+
+interface KeywordBubbleProps {
+  bubbleData: BubbleData;
+}
+
+const KeywordBubble = ({ bubbleData }: KeywordBubbleProps) => {
+  return (
+    <div
+      className={cx('bubble')}
+      style={{
+        transform: `translate(${bubbleData.posX}px, ${bubbleData.posY}px)`,
+        width: `${bubbleData.radius * 5}px`,
+        height: `${bubbleData.radius * 5}px`,
+        fontSize: `${10 + bubbleData.radius * 1}px`,
+      }}
+    >
+      <span>{bubbleData.keyword}</span>
+    </div>
+  );
+};
+
+export default KeywordBubble;

--- a/frontend/components/community/KeywordBubbleChart.tsx
+++ b/frontend/components/community/KeywordBubbleChart.tsx
@@ -1,14 +1,48 @@
+import { useEffect, useState } from 'react';
+import { BubbleData, KeywordData } from '../../types/types';
+import KeywordBubble from './KeywordBubble';
 import styles from '@sass/components/community/KeywordBubbleChart.module.scss';
 import classnames from 'classnames/bind';
-import { KeywordData } from '../../types/types';
 const cx = classnames.bind(styles);
 
 interface KeywordBubbleChart {
   communityKeywordData: KeywordData[];
 }
 
+// type ContainerData = {
+//   width: number;
+//   height: number;
+//   startPosX: number;
+//   startPosY: number;
+// };
+
 const KeywordBubbleChart = ({ communityKeywordData }: KeywordBubbleChart) => {
-  return <div className={cx('chart-container')}>1</div>;
+  // const [containerData, setContainerData] = useState<ContainerData | null>(
+  //   null,
+  // );
+  const [bubbleDataList, setBubbleDataList] = useState<BubbleData[]>([]);
+  useEffect(() => {
+    const bubbleDataArray = communityKeywordData.map(
+      (keywordData: KeywordData) => {
+        // TODO: 멋진 시각화 로직으로 바꾸기
+        return {
+          keyword: keywordData.keyword,
+          count: keywordData.count,
+          posX: keywordData.count * 10,
+          posY: keywordData.count * 10,
+          radius: keywordData.count * 10,
+        };
+      },
+    );
+    setBubbleDataList(bubbleDataArray);
+  }, [communityKeywordData]);
+  return (
+    <div className={cx('chart-container')}>
+      {bubbleDataList.map((bubbleData, index) => (
+        <KeywordBubble key={index} bubbleData={bubbleData} />
+      ))}
+    </div>
+  );
 };
 
 export default KeywordBubbleChart;

--- a/frontend/components/community/KeywordBubbleChart.tsx
+++ b/frontend/components/community/KeywordBubbleChart.tsx
@@ -1,0 +1,14 @@
+import styles from '@sass/components/community/KeywordBubbleChart.module.scss';
+import classnames from 'classnames/bind';
+import { KeywordData } from '../../types/types';
+const cx = classnames.bind(styles);
+
+interface KeywordBubbleChart {
+  communityKeywordData: KeywordData[];
+}
+
+const KeywordBubbleChart = ({ communityKeywordData }: KeywordBubbleChart) => {
+  return <div className={cx('chart-container')}>1</div>;
+};
+
+export default KeywordBubbleChart;

--- a/frontend/components/community/index.ts
+++ b/frontend/components/community/index.ts
@@ -2,6 +2,7 @@ import AutoComplete from './AutoComplete';
 import CommunityHeader from './CommunityHeader';
 import CommunityLayout from './CommunityLayout';
 import KeywordAddModal from './KeywordAddModal';
+import KeywordBubbleChart from './KeywordBubbleChart';
 import MyKeyword from './MyKeyword';
 import MyKeywordList from './MyKeywordList';
 
@@ -10,6 +11,7 @@ export {
   CommunityHeader,
   CommunityLayout,
   KeywordAddModal,
+  KeywordBubbleChart,
   MyKeyword,
   MyKeywordList,
 };

--- a/frontend/pages/community/[id].tsx
+++ b/frontend/pages/community/[id].tsx
@@ -37,6 +37,7 @@ const Community = () => {
       { keyword: '가나다', count: 2 },
       { keyword: '가나라', count: 3 },
       { keyword: '가나라마', count: 3 },
+      { keyword: '가나라마바사아자카파타하', count: 5 },
     ];
 
     const username = localStorage.getItem('waglewagle-username');

--- a/frontend/pages/community/[id].tsx
+++ b/frontend/pages/community/[id].tsx
@@ -5,11 +5,16 @@ import {
   CommunityHeader,
   CommunityLayout,
   KeywordAddModal,
+  KeywordBubbleChart,
 } from '@components/community';
 import { useEffect, useState } from 'react';
+import { KeywordData } from '../../types/types';
 
 const Community = () => {
   const [userData, setUserData] = useState<string | null>('');
+  const [communityKeywordData, setCommunityKeywordData] = useState<
+    KeywordData[]
+  >([]);
   const [isOpenLoginModal, setIsOpenLoginModal] = useState<boolean>(false);
   const [isOpenKeywordModal, setIsOpenKeywordModal] = useState<boolean>(false);
 
@@ -22,8 +27,21 @@ const Community = () => {
   };
 
   useEffect(() => {
+    // TODO : 나중에는 서버에서 받아와야한다.
+    const mockWordList = [
+      { keyword: '가', count: 3 },
+      { keyword: '다', count: 3 },
+      { keyword: '나', count: 3 },
+      { keyword: '가나', count: 3 },
+      { keyword: '가다', count: 3 },
+      { keyword: '가나다', count: 2 },
+      { keyword: '가나라', count: 3 },
+      { keyword: '가나라마', count: 3 },
+    ];
+
     const username = localStorage.getItem('waglewagle-username');
     setUserData(username);
+    setCommunityKeywordData(mockWordList);
   }, []);
 
   return (
@@ -34,7 +52,8 @@ const Community = () => {
         handleClickKeywordModal={handleClickKeywordModal}
         handleClickEnter={handleClickEnter}
       />
-      <AutoComplete />
+      <KeywordBubbleChart communityKeywordData={communityKeywordData} />
+      <AutoComplete communityKeywordData={communityKeywordData} />
       <Modal
         isOpenModal={isOpenLoginModal}
         closeModal={() => setIsOpenLoginModal(false)}

--- a/frontend/sass/components/community/KeywordBubble.module.scss
+++ b/frontend/sass/components/community/KeywordBubble.module.scss
@@ -1,0 +1,32 @@
+@import '@sass/variables.scss';
+
+.bubble {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background-color: $primary-color;
+  transition: all 0.3s ease-in-out;
+  &:hover {
+    border: 1px solid $primary-color;
+    scale: 1.2;
+    background-color: $off-white-color;
+    cursor: pointer;
+    span {
+      color: $primary-color;
+    }
+  }
+
+  span {
+    display: block;
+    width: 90%;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    color: $off-white-color;
+    text-align: center;
+    font-family: 'Nanum BugGeugSeong';
+    transition: background-color 0.1s ease-in;
+  }
+}

--- a/frontend/sass/components/community/KeywordBubbleChart.module.scss
+++ b/frontend/sass/components/community/KeywordBubbleChart.module.scss
@@ -1,0 +1,3 @@
+.chart-container {
+  display: flex;
+}

--- a/frontend/types/types.ts
+++ b/frontend/types/types.ts
@@ -1,0 +1,4 @@
+export type KeywordData = {
+  keyword: string;
+  count: number;
+};

--- a/frontend/types/types.ts
+++ b/frontend/types/types.ts
@@ -2,3 +2,11 @@ export type KeywordData = {
   keyword: string;
   count: number;
 };
+
+export type BubbleData = {
+  keyword: string;
+  count: number;
+  posX: number;
+  posY: number;
+  radius: number;
+};


### PR DESCRIPTION
# 🏗️ 작업 배경

- 배치 알고리즘을 구현하기 전에 버블 차트 스타일 작업을 먼저 진행하기로 함.
- 일단 눈에 보이는 것이 먼저 나와야 작업이 진행되는 이유가 하나였고
- 미리 구현해두면 배치 알고리즘 작업을 진행하며 변경 사항을 눈으로 볼 수 있기 때문 (테스트 코드처럼)
- 또한 하나를 미리 끝내두고 가야 디버깅을 할 때 문제 인식이 더 정확하게 될 수 있다고 판단하기도 하였음.

# 💻 작업 내용

![image](https://user-images.githubusercontent.com/69471032/203589182-59f36ad2-6a8f-445b-b017-3ea87e816b01.png)

- 키워드 목록 Mocking
- 키워드 컨테이너 레이아웃 생성
- 키워드 버블 컴포넌트 생성 (지정 width 넘어가면 ... 이 되도록 설정)
- 키워드 버블 호버 시 인터랙션 구현

# 🎃 이후 작업 내용

- 배치를 위한 방법들에 대해 더 찾아보고, 논의하기로 함.
- 논의 이후 구현은 다음 날로 이동 (2022.11.24.)
- 객체지향을 통해 물리엔진을 구현, 이 물리엔진을 통해서 충돌과 중력을 통해 자연스러운 circle packing을 통해서 버블차트를 구현하기로함.