### PR TITLE
[fix] Github Oauth2 관련 환경 변수 반영 && 어플리케이션 백그라운드 실행 버그 수정

### DIFF
--- a/.github/workflows/rest-cicd.yml
+++ b/.github/workflows/rest-cicd.yml
@@ -12,6 +12,7 @@ env:
   REST_CLONE_URL: https://github.com/boostcampwm-2022/web17-waglewagle.git
   REST_CLONE_BRANCH: be/release
   REST_SECRET_YML_PATH: rest/src/main/resources/secret.yml
+  REST_REST_APPLICATION_OAUTH_YML_PATH: rest/src/main/resources/application-oauth.yml
   REST_GRADLEW_PATH: /root/rest_deploy/rest/gradlew
 
 jobs:
@@ -35,6 +36,7 @@ jobs:
             rm -rf ${{ env.REST_DEPLOY_DIRNAME }}
             git clone -b ${{ env.REST_CLONE_BRANCH }} --single-branch ${{ env.REST_CLONE_URL }} ${{ env.REST_DEPLOY_DIRNAME }}
             echo '${{ secrets.REST_SECRET_YML }}' > ${{ env.REST_DEPLOY_DIRNAME }}/${{ env.REST_SECRET_YML_PATH }}
+            echo '${{ secrets.REST_APPLICATION_OAUTH_YML }}' > ${{ env.REST_DEPLOY_DIRNAME }}/${{ env.REST_REST_APPLICATION_OAUTH_YML_PATH }}
             cd ${{ env.REST_DEPLOY_DIRNAME }}/rest/
             ./gradlew bootJar
             fuser -k -n tcp 8080


### PR DESCRIPTION
# 🏗️ 작업 배경

- appleboy/ssh action에서 nohup ... & 명령어로 어플리케이션을 background에서 실행하였지만, 러너의 foreground에서 실행되던 버그가 발생
- CI/CD 과정에서 빌드 실패 오류 발생

# 💻 작업 내용

- Github Oauth2 인증 및 인가에 필요한 환경 변수가 설정된 파일 추가.
