### PR TITLE
[Feat] 로그인 모달창 api 연결 및 모달창 UI 수정

### DIFF
--- a/frontend/components/common/LoginModalContent.tsx
+++ b/frontend/components/common/LoginModalContent.tsx
@@ -1,45 +1,19 @@
 import classnames from 'classnames/bind';
 import styles from '@sass/components/common/LoginModalContent.module.scss';
 import { AiFillGithub } from 'react-icons/ai';
-import { ChangeEvent, useState } from 'react';
 const cx = classnames.bind(styles);
 
 const LoginModalContent = () => {
-  const [username, setUsername] = useState<string>('');
-
-  const onChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setUsername(e.target.value);
-  };
-
-  const handleSubmitUsernameLogin = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    localStorage.setItem('waglewagle-username', username); // 임시 유저데이터
-    // apis.fetchLogin(username);
-    setUsername('');
-  };
-
   return (
     <div className={cx('container')}>
       <h2 className={cx('title')}>로그인</h2>
-      <form
-        className={cx('username-login-form')}
-        onSubmit={handleSubmitUsernameLogin}
+      <a
+        href='http://localhost:8080/oauth2/authorization/github'
+        className={cx('github-login-button')}
       >
-        <input
-          value={username}
-          onChange={onChange}
-          className={cx('username-input')}
-          placeholder='유저이름'
-        />
-        <button type='submit' className={cx('login-button')}>
-          로그인
-        </button>
-      </form>
-      <hr />
-      <button className={cx('github-login-button')}>
         <AiFillGithub />
         깃허브로 로그인하기
-      </button>
+      </a>
     </div>
   );
 };

--- a/frontend/components/common/LoginModalContent.tsx
+++ b/frontend/components/common/LoginModalContent.tsx
@@ -1,6 +1,7 @@
 import classnames from 'classnames/bind';
 import styles from '@sass/components/common/LoginModalContent.module.scss';
 import { AiFillGithub } from 'react-icons/ai';
+import config from '../../config';
 const cx = classnames.bind(styles);
 
 const LoginModalContent = () => {
@@ -8,7 +9,7 @@ const LoginModalContent = () => {
     <div className={cx('container')}>
       <h2 className={cx('title')}>로그인</h2>
       <a
-        href='http://localhost:8080/oauth2/authorization/github'
+        href={`${config.API_HOST}/oauth2/authorization/github`}
         className={cx('github-login-button')}
       >
         <AiFillGithub />

--- a/frontend/components/common/StartButton.tsx
+++ b/frontend/components/common/StartButton.tsx
@@ -7,7 +7,7 @@ const cx = classnames.bind(styles);
 // TODO : 버튼 기능이 페이지 이동으로 수정되며 추가된 버튼. DefaultButton 컴포넌트를 어떻게 할지 논의하기
 const StartButton = () => {
   return (
-    <Link className={cx('default')} href='/community/1'>
+    <Link className={cx('default')} href='http://localhost:3000/community/1'>
       <DefaultButton width={200} height={40} fontSize={18}>
         시작하기
       </DefaultButton>

--- a/frontend/components/community/CommunityLayout.tsx
+++ b/frontend/components/community/CommunityLayout.tsx
@@ -1,11 +1,14 @@
 import { ReactNode } from 'react';
+import styles from '@sass/components/community/CommunityLayout.module.scss';
+import classnames from 'classnames/bind';
+const cx = classnames.bind(styles);
 
 interface CommunityLayoutProps {
   children: ReactNode;
 }
 
 const CommunityLayout = ({ children }: CommunityLayoutProps) => {
-  return <div>{children}</div>;
+  return <div className={cx('layout')}>{children}</div>;
 };
 
 export default CommunityLayout;

--- a/frontend/components/home/HomeHero.tsx
+++ b/frontend/components/home/HomeHero.tsx
@@ -3,24 +3,10 @@ import heroImage from '@public/images/planet.png';
 import classnames from 'classnames/bind';
 import styles from '@sass/components/home/HomeHero.module.scss';
 const cx = classnames.bind(styles);
-import axios from 'axios';
 
 const HomeHero = () => {
-  // TODO : 지우기
-  const getCookie = () => {
-    axios
-      .get('http://www.waglewagle.link/api')
-      .then((response) => {
-        alert(
-          `서버에서 쿠키를 잘 받아왔습니다. 개발자도구 어플리케이션 탭에서 확인해주세요 값 : ${response.data}`,
-        );
-      })
-      .catch(() => {
-        alert('서버 통신에 실패했습니다.');
-      });
-  };
   return (
-    <div onClick={getCookie} className={cx('image-container')}>
+    <div className={cx('image-container')}>
       <Image src={heroImage} alt='행성 사진' height={350} />
     </div>
   );

--- a/frontend/pages/community/[id].tsx
+++ b/frontend/pages/community/[id].tsx
@@ -7,7 +7,7 @@ import {
   KeywordAddModal,
   KeywordBubbleChart,
 } from '@components/community';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 const Community = () => {
   const [userData, setUserData] = useState<string | null>('');
@@ -21,6 +21,13 @@ const Community = () => {
   const handleClickKeywordModal = () => {
     setIsOpenKeywordModal(true);
   };
+
+  useEffect(() => {
+    const username = localStorage.getItem('waglewagle-username');
+    if (username) {
+      setUserData(username);
+    }
+  }, []);
 
   return (
     <CommunityLayout>

--- a/frontend/sass/components/common/LoginModalContent.module.scss
+++ b/frontend/sass/components/common/LoginModalContent.module.scss
@@ -19,48 +19,18 @@ $border-radius: 10px;
 
 .container {
   width: 400px;
-  height: 300px;
   padding: 10px;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   align-items: center;
-
-  hr {
-    width: 100%;
-  }
 }
 
 .title {
+  margin-bottom: 20px;
   text-align: center;
   font-size: 2.5rem;
   font-family: 'Nanum BugGeugSeong';
-}
-
-.username-login-form {
-  flex-direction: column;
-  @include flex-center;
-  gap: 20px;
-}
-
-.username-input {
-  width: 300px;
-  height: 40px;
-  border-radius: 5px;
-  text-align: center;
-  &::placeholder {
-    text-align: center;
-  }
-}
-
-.login-button {
-  width: 150px;
-  height: 40px;
-  border-radius: $border-radius;
-  background-color: $primary-color;
-  color: $off-white-color;
-
-  @include button-interaction;
 }
 
 .github-login-button {

--- a/frontend/sass/components/community/CommunityHeader.module.scss
+++ b/frontend/sass/components/community/CommunityHeader.module.scss
@@ -1,9 +1,12 @@
 .header {
+  position: relative;
   display: flex;
   justify-content: space-between;
   max-width: 1320px;
   margin: 0 auto;
   padding: 20px;
+  background-color: transparent;
+  z-index: 9;
 }
 
 .left-header {

--- a/frontend/sass/components/community/CommunityLayout.module.scss
+++ b/frontend/sass/components/community/CommunityLayout.module.scss
@@ -1,3 +1,5 @@
 .layout {
   position: relative;
+  width: 100%;
+  height: 100%;
 }

--- a/frontend/sass/components/community/KeywordBubbleChart.module.scss
+++ b/frontend/sass/components/community/KeywordBubbleChart.module.scss
@@ -1,8 +1,8 @@
 .chart-container {
   position: absolute;
   display: flex;
-  width: 100vw;
-  height: 100vh;
+  width: 100%;
+  height: 100%;
   top: 0;
   overflow: hidden;
 }

--- a/frontend/sass/globals.scss
+++ b/frontend/sass/globals.scss
@@ -14,7 +14,10 @@ html {
 }
 
 html,
-body {
+body,
+#__next {
+  width: 100%;
+  height: 100%;
   scroll-behavior: smooth;
   background-color: #fcfcfc;
   color: #112a4a;


### PR DESCRIPTION
# 🏗️ 작업배경

- username 로그인을 삭제하고, oauth 로그인만 남겨둠.
- spring security의 기능으로 인해서 github authorization으로 연결하지 않고, api만 요청함. 이를 통해서 client_id가 노출되지 않는 보안적인 장점이 있음.

# 💻  작업내용

![image](https://user-images.githubusercontent.com/69471032/204807406-680dc3b8-e37c-42c8-8417-1fdecce2e773.png)

- UI 수정작업
- API를 연결함. API 에러로 현재는 동작하지 않음.
- z-index와 width, height, position 미적용으로 데이터 시각화 부분에 덮여서 헤더가 클릭되지 않던 에러를 해결함. 해당 트러블 슈팅 정리해두었음. [보러가기](https://enormous-iguanadon-33a.notion.site/z-index-position-e73e996420634ee2b80f8b5b1816e09c)

# 🤔 개선가능한 부분

- spring security를 빼고 nextjs의 rewrite를 사용해서 client_id를 숨길 수 있음.