### PR TITLE
[Feat] (미완) 키워드 추가 컴포넌트 구현

### DIFF
--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,1 +1,1 @@
-NEXT_PUBLIC_API_HOST = 'http://localhost:8080/api'
+NEXT_PUBLIC_API_HOST = 'http://localhost/api'

--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,1 +1,2 @@
-NEXT_PUBLIC_API_HOST = 'http://localhost/api'
+NEXT_PUBLIC_API_HOST = 'http://localhost:8080/api'
+NEXT_PUBLIC_NGINX_API_HOST = 'http://localhost/api'

--- a/frontend/apis/apis.ts
+++ b/frontend/apis/apis.ts
@@ -1,4 +1,10 @@
-import { KeywordAssociationData, UserData } from './../types/types';
+import {
+  AddKeywordData,
+  AddKeywordResponseData,
+  JoinKeywordData,
+  KeywordRelatedData,
+  UserData,
+} from './../types/types';
 import axios from 'axios';
 import config from '../config';
 import { KeywordData } from '../types/types';
@@ -15,27 +21,27 @@ const fetchLogin = async (username: string) => {
   return response;
 };
 
-const getUserMe = async (): Promise<UserData> => {
-  const response = await apiInstance.get('/v1/user/me');
-
-  return response.data;
-};
-
 const getKeywords = async (id: string): Promise<KeywordData[]> => {
   const response = await apiInstance.get(`/v1/keyword/${id}`);
 
   return response.data;
 };
 
-const getUserData = async () => {
+const joinKeyword = async (joinKeywordData: JoinKeywordData) => {
+  await apiInstance.post('/v1/keyword/join', {
+    data: joinKeywordData,
+  });
+};
+
+const getUserData = async (): Promise<UserData> => {
   const response = await apiInstance.get('/v1/user/me');
 
-  return response;
+  return response.data;
 };
 
 const getKeywordAssociations = async (
   id: string,
-): Promise<KeywordAssociationData[]> => {
+): Promise<KeywordRelatedData[]> => {
   const response = await apiInstance.get('/v1/keyword/associations', {
     params: {
       'keyword-id': id,
@@ -45,10 +51,21 @@ const getKeywordAssociations = async (
   return response.data;
 };
 
+const addKeyword = async (
+  addKeywordData: AddKeywordData,
+): Promise<AddKeywordResponseData> => {
+  const response = await apiInstance.post('/v1/keyword', {
+    data: addKeywordData,
+  });
+
+  return response.data;
+};
+
 const apis = {
   fetchLogin,
-  getUserMe,
   getKeywords,
+  joinKeyword,
+  addKeyword,
   getUserData,
   getKeywordAssociations,
 };

--- a/frontend/apis/apis.ts
+++ b/frontend/apis/apis.ts
@@ -1,4 +1,4 @@
-import { KeywordAssociationData } from './../types/types';
+import { KeywordAssociationData, UserData } from './../types/types';
 import axios from 'axios';
 import config from '../config';
 import { KeywordData } from '../types/types';
@@ -13,6 +13,12 @@ const fetchLogin = async (username: string) => {
   });
 
   return response;
+};
+
+const getUserMe = async (): Promise<UserData> => {
+  const response = await apiInstance.get('/v1/user/me');
+
+  return response.data;
 };
 
 const getKeywords = async (id: string): Promise<KeywordData[]> => {
@@ -41,6 +47,7 @@ const getKeywordAssociations = async (
 
 const apis = {
   fetchLogin,
+  getUserMe,
   getKeywords,
   getUserData,
   getKeywordAssociations,

--- a/frontend/apis/apis.ts
+++ b/frontend/apis/apis.ts
@@ -1,3 +1,4 @@
+import { KeywordAssociationData } from './../types/types';
 import axios from 'axios';
 import config from '../config';
 import { KeywordData } from '../types/types';
@@ -26,10 +27,23 @@ const getUserData = async () => {
   return response;
 };
 
+const getKeywordAssociations = async (
+  id: string,
+): Promise<KeywordAssociationData[]> => {
+  const response = await apiInstance.get('/v1/keyword/associations', {
+    params: {
+      'keyword-id': id,
+    },
+  });
+
+  return response.data;
+};
+
 const apis = {
   fetchLogin,
   getKeywords,
   getUserData,
+  getKeywordAssociations,
 };
 
 export default apis;

--- a/frontend/components/common/LoginModalContent.tsx
+++ b/frontend/components/common/LoginModalContent.tsx
@@ -4,7 +4,11 @@ import { ChangeEvent, useState } from 'react';
 import apis from '../../apis/apis';
 const cx = classnames.bind(styles);
 
-const LoginModalContent = () => {
+interface LoginModalContentProps {
+  closeLoginModal: () => void;
+}
+
+const LoginModalContent = ({ closeLoginModal }: LoginModalContentProps) => {
   const [username, setUsername] = useState<string>('');
 
   const onChange = (e: ChangeEvent<HTMLInputElement>) => {
@@ -16,6 +20,7 @@ const LoginModalContent = () => {
     // localStorage.setItem('waglewagle-username', username); // 임시 유저데이터
     apis.fetchLogin(username);
     setUsername('');
+    closeLoginModal();
   };
 
   return (

--- a/frontend/components/common/LoginModalContent.tsx
+++ b/frontend/components/common/LoginModalContent.tsx
@@ -1,7 +1,7 @@
 import classnames from 'classnames/bind';
 import styles from '@sass/components/common/LoginModalContent.module.scss';
-import { AiFillGithub } from 'react-icons/ai';
 import { ChangeEvent, useState } from 'react';
+import apis from '../../apis/apis';
 const cx = classnames.bind(styles);
 
 const LoginModalContent = () => {
@@ -13,8 +13,8 @@ const LoginModalContent = () => {
 
   const handleSubmitUsernameLogin = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    localStorage.setItem('waglewagle-username', username); // 임시 유저데이터
-    // apis.fetchLogin(username);
+    // localStorage.setItem('waglewagle-username', username); // 임시 유저데이터
+    apis.fetchLogin(username);
     setUsername('');
   };
 
@@ -35,11 +35,11 @@ const LoginModalContent = () => {
           로그인
         </button>
       </form>
-      <hr />
-      <button className={cx('github-login-button')}>
+      {/* <hr /> */}
+      {/* <button className={cx('github-login-button')}>
         <AiFillGithub />
         깃허브로 로그인하기
-      </button>
+      </button> */}
     </div>
   );
 };

--- a/frontend/components/community/AutoCompleteFormLayout.tsx
+++ b/frontend/components/community/AutoCompleteFormLayout.tsx
@@ -15,7 +15,7 @@ const AutoCompleteFormLayout = ({
   handleSubmit,
 }: AutoCompleteFormLayoutProps) => {
   return (
-    <form onSubmit={handleSubmit} className={cx(`${layoutTheme}`)}>
+    <form onSubmit={handleSubmit} className={cx(layoutTheme)}>
       {children}
     </form>
   );

--- a/frontend/components/community/CommunityHeader.tsx
+++ b/frontend/components/community/CommunityHeader.tsx
@@ -1,3 +1,4 @@
+import useUserMe from '@hooks/useUserMe';
 import styles from '@sass/components/community/CommunityHeader.module.scss';
 import classnames from 'classnames/bind';
 import Image from 'next/image';
@@ -5,17 +6,17 @@ const cx = classnames.bind(styles);
 
 interface CommunityHeaderProps {
   title: string;
-  userData: string | null;
   handleClickEnter: () => void;
   handleClickKeywordModal: () => void;
 }
 
 const CommunityHeader = ({
   title,
-  userData,
   handleClickEnter,
   handleClickKeywordModal,
 }: CommunityHeaderProps) => {
+  const userData = useUserMe();
+
   return (
     <header className={cx('header')}>
       <div className={cx('left-header')}>

--- a/frontend/components/community/KeywordAddModal.tsx
+++ b/frontend/components/community/KeywordAddModal.tsx
@@ -1,11 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import MyKeyword from './MyKeyword';
 import MyKeywordList from './MyKeywordList';
-import { GrPowerReset } from 'react-icons/gr';
 import KeywordAssociated from './KeywordAssociated';
 import styles from '@sass/components/community/KeywordAddModal.module.scss';
 import classnames from 'classnames/bind';
-import TrieSearchEngine from '../../utils/TrieSearchEngine';
+import KeywordAdder from './KeywordAdder';
 const cx = classnames.bind(styles);
 
 type keywordProps = {
@@ -13,47 +12,8 @@ type keywordProps = {
   id: string;
 };
 
-const searchEngine = new TrieSearchEngine();
-
 const KeywordAddModal = () => {
   const [myKeywordList, setMyKeywordList] = useState<keywordProps[] | []>([]);
-  const [searchKeyword, setSearchKeyword] = useState<string>('');
-  const [searchResult, setSearchResult] = useState<string[]>(['']);
-  const [isOpenDropdown, setIsOpenDropDown] = useState<boolean>(false);
-
-  const handleSearchSubmit: React.FormEventHandler<HTMLFormElement> = (e) => {
-    e.preventDefault();
-    const searchEngineResult = searchEngine.search(searchKeyword);
-    setSearchResult(searchEngineResult);
-    setIsOpenDropDown(true);
-    setSearchKeyword('');
-  };
-
-  const handleChangeSearchKeyword: React.ChangeEventHandler<
-    HTMLInputElement
-  > = (e) => {
-    setSearchKeyword(e.target.value);
-  };
-
-  useEffect(() => {
-    // TODO : 나중에는 서버에서 받아와야한다.
-    const mockWordList = [
-      { keyword: '가', count: 3 },
-      { keyword: '다', count: 3 },
-      { keyword: '나', count: 3 },
-      { keyword: '가나', count: 3 },
-      { keyword: '가다', count: 3 },
-      { keyword: '가나다', count: 2 },
-      { keyword: '가나라', count: 3 },
-      { keyword: '가나라마', count: 3 },
-    ];
-
-    mockWordList.forEach((word) => {
-      searchEngine.insert(word);
-    });
-
-    setSearchResult(mockWordList.map(({ keyword }) => keyword));
-  }, []);
 
   useEffect(() => {
     setMyKeywordList([
@@ -72,35 +32,12 @@ const KeywordAddModal = () => {
     <div className={cx('container')}>
       <header className={cx('header')}>
         <h3 className={cx('title')}>세 개 이상 추가해보세요</h3>
-        <button className={cx('reset-button')}>
-          {/* 지금은 선택이 없어서 지워야할까? 헤더에 들어가는게 맞을까? UX적으로 맞다고 할 수도 있지 않을까? */}
-          <GrPowerReset />
-        </button>
+        {/* 지금은 필요 없어서 리셋버튼 삭제 */}
       </header>
       <main className={cx('main')}>
         <section className={cx('keyword-add-section')}>
           <div className={cx('keyword-add-container')}>
-            <form
-              onSubmit={handleSearchSubmit}
-              className={cx('keyword-add-form')}
-            >
-              <input
-                onFocus={() => setIsOpenDropDown(true)}
-                onBlur={() => setIsOpenDropDown(false)}
-                onChange={handleChangeSearchKeyword}
-                value={searchKeyword}
-                className={cx('keyword-add-input')}
-              />
-              <button className={cx('keyword-add-button')}>추가하기</button>
-            </form>
-            {/* TODO: 리팩토링때 추상화시켜서 공통으로 쓰기*/}
-            {isOpenDropdown && (
-              <ul className={cx('search-result-list')}>
-                {searchResult.map((word) => (
-                  <li key={word}>{word}</li>
-                ))}
-              </ul>
-            )}
+            <KeywordAdder theme='modal' addButtonValue='추가하기' />
           </div>
           {/* 키워드 추천은 추가 섹션과 기능적으로 연관되어있다고 할 수 있을까? */}
           <KeywordAssociated />

--- a/frontend/components/community/KeywordAddModal.tsx
+++ b/frontend/components/community/KeywordAddModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, MouseEventHandler } from 'react';
 import MyKeyword from './MyKeyword';
 import MyKeywordList from './MyKeywordList';
 import KeywordAssociated from './KeywordAssociated';
@@ -14,6 +14,14 @@ type keywordProps = {
 
 const KeywordAddModal = () => {
   const [myKeywordList, setMyKeywordList] = useState<keywordProps[] | []>([]);
+
+  const handleDeleteClick: MouseEventHandler<HTMLButtonElement> = (e) => {
+    const target = e.target as HTMLElement;
+    const filteredList = myKeywordList.filter(
+      (keyword) => keyword.keyword !== target.previousSibling?.textContent,
+    );
+    setMyKeywordList(filteredList);
+  };
 
   useEffect(() => {
     setMyKeywordList([
@@ -47,7 +55,11 @@ const KeywordAddModal = () => {
           <h4 className={cx('my-keyword-title')}>내 키워드</h4>
           <MyKeywordList>
             {myKeywordList.map((keywordData) => (
-              <MyKeyword key={keywordData.id} keyword={keywordData.keyword} />
+              <MyKeyword
+                handleDeleteClick={handleDeleteClick}
+                key={keywordData.id}
+                keyword={keywordData.keyword}
+              />
             ))}
           </MyKeywordList>
           <button className={cx('enter-button')}>입장하기</button>

--- a/frontend/components/community/KeywordAddModal.tsx
+++ b/frontend/components/community/KeywordAddModal.tsx
@@ -1,45 +1,30 @@
-import React, { useEffect, useState, MouseEventHandler } from 'react';
+import React, { MouseEventHandler } from 'react';
 import MyKeyword from './MyKeyword';
 import MyKeywordList from './MyKeywordList';
 import KeywordAssociated from './KeywordAssociated';
 import styles from '@sass/components/community/KeywordAddModal.module.scss';
 import classnames from 'classnames/bind';
 import KeywordAdder from './KeywordAdder';
+import useUserKeywordList from '@hooks/useUserKeywordList';
 const cx = classnames.bind(styles);
 
-type keywordProps = {
-  keyword: string;
-  id: string;
-};
-
 const KeywordAddModal = () => {
-  const [myKeywordList, setMyKeywordList] = useState<keywordProps[] | []>([]);
+  const { myKeywordList, handleChangeMyKeywordList } = useUserKeywordList();
 
   const handleDeleteClick: MouseEventHandler<HTMLButtonElement> = (e) => {
     const target = e.target as HTMLElement;
     const filteredList = myKeywordList.filter(
-      (keyword) => keyword.keyword !== target.previousSibling?.textContent,
+      (keyword) => keyword.keywordName !== target.previousSibling?.textContent,
     );
-    setMyKeywordList(filteredList);
+    handleChangeMyKeywordList(filteredList);
   };
-
-  useEffect(() => {
-    setMyKeywordList([
-      {
-        keyword: '논',
-        id: '1',
-      },
-      {
-        keyword: '밭',
-        id: '2',
-      },
-    ]);
-  }, []);
 
   return (
     <div className={cx('container')}>
       <header className={cx('header')}>
-        <h3 className={cx('title')}>세 개 이상 추가해보세요</h3>
+        <h3 className={cx('title')}>
+          세 개 이상 추가해보세요 (키워드를 추가해보세요?)
+        </h3>
         {/* 지금은 필요 없어서 리셋버튼 삭제 */}
       </header>
       <main className={cx('main')}>
@@ -54,13 +39,14 @@ const KeywordAddModal = () => {
           <hr />
           <h4 className={cx('my-keyword-title')}>내 키워드</h4>
           <MyKeywordList>
-            {myKeywordList.map((keywordData) => (
-              <MyKeyword
-                handleDeleteClick={handleDeleteClick}
-                key={keywordData.id}
-                keyword={keywordData.keyword}
-              />
-            ))}
+            {myKeywordList &&
+              myKeywordList.map((keywordData) => (
+                <MyKeyword
+                  handleDeleteClick={handleDeleteClick}
+                  key={keywordData.keywordId}
+                  keyword={keywordData.keywordName}
+                />
+              ))}
           </MyKeywordList>
           <button className={cx('enter-button')}>입장하기</button>
         </section>

--- a/frontend/components/community/KeywordAdder.tsx
+++ b/frontend/components/community/KeywordAdder.tsx
@@ -5,7 +5,6 @@ import {
   SearchResultListLayout,
   AutoCompleteFormLayout,
 } from '@components/community';
-import AddCircleIcon from '@public/images/add-circle.svg';
 import styles from '@sass/components/community/KeywordAdderLayout.module.scss';
 import classnames from 'classnames/bind';
 import useKeywordListQuery from '@hooks/useKeywordListQuery';
@@ -13,9 +12,10 @@ const cx = classnames.bind(styles);
 
 interface KeywordAdderProps {
   theme: string;
+  addButtonValue: React.ReactNode | string;
 }
 
-const KeywordAdder = ({ theme }: KeywordAdderProps) => {
+const KeywordAdder = ({ theme, addButtonValue }: KeywordAdderProps) => {
   const router = useRouter();
   const communityId: string = router.query.id as string;
   const communityKeywordData = useKeywordListQuery(communityId);
@@ -42,7 +42,7 @@ const KeywordAdder = ({ theme }: KeywordAdderProps) => {
   };
 
   return (
-    <div className={cx('keyword-adder')}>
+    <div className={cx(theme)}>
       {isOpenDropdown && (
         <SearchResultListLayout layoutTheme={theme}>
           {searchResult.map((word, index) => (
@@ -58,9 +58,7 @@ const KeywordAdder = ({ theme }: KeywordAdderProps) => {
           onFocus={() => setIsOpenDropDown(true)}
           onBlur={() => setIsOpenDropDown(false)}
         />
-        <button type='submit'>
-          <AddCircleIcon />
-        </button>
+        <button type='submit'>{addButtonValue}</button>
       </AutoCompleteFormLayout>
     </div>
   );

--- a/frontend/components/community/KeywordAdder.tsx
+++ b/frontend/components/community/KeywordAdder.tsx
@@ -1,21 +1,14 @@
-import {
-  ChangeEventHandler,
-  FormEventHandler,
-  useEffect,
-  useState,
-} from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { ChangeEventHandler, FormEventHandler, useState } from 'react';
 import { useRouter } from 'next/router';
 import useAutoComplete from '@hooks/useAutoComplete';
 import {
   SearchResultListLayout,
   AutoCompleteFormLayout,
 } from '@components/community';
-import apis from '../../apis/apis';
-import { KeywordData } from '../../types/types';
 import AddCircleIcon from '@public/images/add-circle.svg';
 import styles from '@sass/components/community/KeywordAdderLayout.module.scss';
 import classnames from 'classnames/bind';
+import useKeywordListQuery from '@hooks/useKeywordListQuery';
 const cx = classnames.bind(styles);
 
 interface KeywordAdderProps {
@@ -25,20 +18,7 @@ interface KeywordAdderProps {
 const KeywordAdder = ({ theme }: KeywordAdderProps) => {
   const router = useRouter();
   const communityId: string = router.query.id as string;
-  const { data } = useQuery<KeywordData[]>(
-    ['keyword', communityId],
-    () => {
-      const data = apis.getKeywords(communityId);
-      return data;
-    },
-    {
-      enabled: !!communityId,
-    },
-  );
-
-  const [communityKeywordData, setCommunityKeywordData] = useState<
-    KeywordData[]
-  >([]);
+  const communityKeywordData = useKeywordListQuery(communityId);
   const {
     searchKeyword,
     searchResult,
@@ -60,13 +40,6 @@ const KeywordAdder = ({ theme }: KeywordAdderProps) => {
   ) => {
     changeSearchKeyword(e.target.value);
   };
-
-  useEffect(() => {
-    if (!data) {
-      return;
-    }
-    setCommunityKeywordData(data);
-  }, [data]);
 
   return (
     <div className={cx('keyword-adder')}>

--- a/frontend/components/community/KeywordAdder.tsx
+++ b/frontend/components/community/KeywordAdder.tsx
@@ -13,6 +13,7 @@ import {
 import styles from '@sass/components/community/KeywordAdderLayout.module.scss';
 import classnames from 'classnames/bind';
 import useKeywordListQuery from '@hooks/useKeywordListQuery';
+import apis from '../../apis/apis';
 const cx = classnames.bind(styles);
 
 interface KeywordAdderProps {
@@ -33,10 +34,46 @@ const KeywordAdder = ({ theme, addButtonValue }: KeywordAdderProps) => {
   // TODO: 자동완성 컴포넌트 추상화하면서 거기로 넘기기
   const [isOpenDropdown, setIsOpenDropDown] = useState<boolean>(false);
 
-  const handleSubmit: FormEventHandler<HTMLFormElement> = (e) => {
+  const getKeywordAssociations = async (keywordId: string) => {
+    const keywordAssociationsData = await apis.getKeywordAssociations(
+      keywordId,
+    );
+    console.log(keywordAssociationsData);
+  };
+
+  // TODO: 테스트코드 작성 가능
+  const getKeywordIdByKeyword = (keyword: string): string | false => {
+    // 커뮤니티 키워드 데이터가 없으면 검색할 수 없다.
+    if (!communityKeywordData) {
+      return false;
+    }
+
+    // some을 쓰면 예외처리가 힘들 것 같아서 filter 사용
+    const result = communityKeywordData?.filter(
+      (keywordData) => keywordData.keywordName === keyword,
+    );
+
+    if (result.length === 0) {
+      return false;
+    }
+
+    if (result.length > 1) {
+      // TODO: 커스텀 에러 객체 만들기
+      throw new Error('중복된 id가 있습니다.');
+    }
+
+    return result[0].keywordId;
+  };
+
+  const handleSubmit: FormEventHandler<HTMLFormElement> = async (e) => {
     e.preventDefault();
     setIsOpenDropDown(false);
     changeSearchKeyword('');
+
+    const keywordId = getKeywordIdByKeyword(searchKeyword);
+    if (keywordId) {
+      await getKeywordAssociations(keywordId);
+    }
   };
 
   const handleChangeSearchKeyword: ChangeEventHandler<HTMLInputElement> = (

--- a/frontend/components/community/KeywordAdder.tsx
+++ b/frontend/components/community/KeywordAdder.tsx
@@ -25,10 +25,9 @@ const KeywordAdder = ({ theme, addButtonValue }: KeywordAdderProps) => {
   const communityId: string = router.query.id as string;
   const communityKeywordData = useKeywordListQuery(communityId);
   const {
-    searchKeyword,
+    searchKeyword, // TODO: 이것을 여기서 useAutoComplete에서 관리해주는게 맞을까? 의존제어가 제대로 되고 있는걸까? 자식 컴포넌트처럼 생각해도 될까? 무언가 Badsmell. 그냥 어색한걸까?
     searchResult,
     changeSearchKeyword,
-    updateSearchResult,
   } = useAutoComplete(communityKeywordData);
 
   // TODO: 자동완성 컴포넌트 추상화하면서 거기로 넘기기
@@ -36,13 +35,14 @@ const KeywordAdder = ({ theme, addButtonValue }: KeywordAdderProps) => {
 
   const handleSubmit: FormEventHandler<HTMLFormElement> = (e) => {
     e.preventDefault();
-    setIsOpenDropDown(true);
-    updateSearchResult();
+    setIsOpenDropDown(false);
+    changeSearchKeyword('');
   };
 
   const handleChangeSearchKeyword: ChangeEventHandler<HTMLInputElement> = (
     e,
   ) => {
+    setIsOpenDropDown(true);
     changeSearchKeyword(e.target.value);
   };
 

--- a/frontend/components/community/KeywordAdder.tsx
+++ b/frontend/components/community/KeywordAdder.tsx
@@ -95,9 +95,9 @@ const KeywordAdder = ({ theme, addButtonValue }: KeywordAdderProps) => {
 
   // 이후 분리하여 상위 컴포넌트에서 사용 필요함.
   // TODO: 전역상태관리 쓸지 물어보기
-  // useEffect(() => {
-  //   console.log(keywordAssociations);
-  // }, [keywordAssociations]);
+  useEffect(() => {
+    console.log(keywordAssociations);
+  }, [keywordAssociations]);
 
   return (
     <div

--- a/frontend/components/community/KeywordAdder.tsx
+++ b/frontend/components/community/KeywordAdder.tsx
@@ -32,9 +32,9 @@ const KeywordAdder = ({ theme, addButtonValue }: KeywordAdderProps) => {
     useAutoComplete(communityKeywordData);
   const {
     myKeywordList,
-    recentAssociationKeywordList,
+    relatedKeywordList,
     handleChangeMyKeywordList,
-    handleChangeRecentAssociationKeywordList,
+    handleChangeRelatedKeywordList,
   } = useUserKeywordList();
 
   const [isOpenDropdown, setIsOpenDropDown] = useState<boolean>(false);
@@ -44,7 +44,7 @@ const KeywordAdder = ({ theme, addButtonValue }: KeywordAdderProps) => {
       keywordId,
     );
     const slicedData = keywordAssociationsData.slice(0, 3);
-    handleChangeRecentAssociationKeywordList(slicedData);
+    return slicedData;
   };
 
   const handleSubmit: FormEventHandler<HTMLFormElement> = async (e) => {
@@ -61,9 +61,18 @@ const KeywordAdder = ({ theme, addButtonValue }: KeywordAdderProps) => {
       const newMyKeyword = { keywordId, keywordName: searchKeyword };
       const updatedMyKeywordList = [...myKeywordList, newMyKeyword];
       handleChangeMyKeywordList(updatedMyKeywordList);
-      await getKeywordAssociations(keywordId);
+      const slicedData = await getKeywordAssociations(keywordId);
+      handleChangeRelatedKeywordList(slicedData);
     } else {
-      // 키워드 추가 API, 이후 keyword id를 반환받아서 참가하기 => 이후에는 Mutation으로 수정됨.
+      const body = {
+        keywordName: searchKeyword,
+        communityId,
+      };
+      const result = await apis.addKeyword(body);
+      const updatedMyKeywordList = [...myKeywordList, result];
+      handleChangeMyKeywordList(updatedMyKeywordList);
+      const slicedData = await getKeywordAssociations(result.keywordId);
+      handleChangeRelatedKeywordList(slicedData);
     }
 
     setIsOpenDropDown(false);
@@ -82,12 +91,6 @@ const KeywordAdder = ({ theme, addButtonValue }: KeywordAdderProps) => {
     const target = e.target as HTMLLIElement;
     changeSearchKeyword(target.innerText);
   };
-
-  // 이후 분리하여 상위 컴포넌트에서 사용 필요함.
-  // TODO: 전역상태관리 쓸지 물어보기
-  useEffect(() => {
-    console.log(recentAssociationKeywordList);
-  }, [recentAssociationKeywordList]);
 
   return (
     <div

--- a/frontend/components/community/KeywordAdder.tsx
+++ b/frontend/components/community/KeywordAdder.tsx
@@ -1,4 +1,9 @@
-import { ChangeEventHandler, FormEventHandler, useState } from 'react';
+import {
+  MouseEventHandler,
+  ChangeEventHandler,
+  FormEventHandler,
+  useState,
+} from 'react';
 import { useRouter } from 'next/router';
 import useAutoComplete from '@hooks/useAutoComplete';
 import {
@@ -41,12 +46,24 @@ const KeywordAdder = ({ theme, addButtonValue }: KeywordAdderProps) => {
     changeSearchKeyword(e.target.value);
   };
 
+  const handleMouseDownkResultItem: MouseEventHandler<HTMLLIElement> = (e) => {
+    e.preventDefault();
+    const target = e.target as HTMLLIElement;
+    changeSearchKeyword(target.innerText);
+  };
+
   return (
-    <div className={cx(theme)}>
+    <div
+      className={cx(theme)}
+      onFocus={() => setIsOpenDropDown(true)}
+      onBlur={() => setIsOpenDropDown(false)}
+    >
       {isOpenDropdown && (
         <SearchResultListLayout layoutTheme={theme}>
           {searchResult.map((word, index) => (
-            <li key={index}>{word}</li>
+            <li onMouseDown={handleMouseDownkResultItem} key={index}>
+              {word}
+            </li>
           ))}
         </SearchResultListLayout>
       )}
@@ -55,8 +72,6 @@ const KeywordAdder = ({ theme, addButtonValue }: KeywordAdderProps) => {
           type='text'
           value={searchKeyword}
           onChange={handleChangeSearchKeyword}
-          onFocus={() => setIsOpenDropDown(true)}
-          onBlur={() => setIsOpenDropDown(false)}
         />
         <button type='submit'>{addButtonValue}</button>
       </AutoCompleteFormLayout>

--- a/frontend/components/community/KeywordAdder.tsx
+++ b/frontend/components/community/KeywordAdder.tsx
@@ -3,6 +3,7 @@ import {
   ChangeEventHandler,
   FormEventHandler,
   useState,
+  useEffect,
 } from 'react';
 import { useRouter } from 'next/router';
 import useAutoComplete from '@hooks/useAutoComplete';
@@ -14,6 +15,7 @@ import styles from '@sass/components/community/KeywordAdderLayout.module.scss';
 import classnames from 'classnames/bind';
 import useKeywordListQuery from '@hooks/useKeywordListQuery';
 import apis from '../../apis/apis';
+import { KeywordAssociationData } from '../../types/types';
 const cx = classnames.bind(styles);
 
 interface KeywordAdderProps {
@@ -31,14 +33,17 @@ const KeywordAdder = ({ theme, addButtonValue }: KeywordAdderProps) => {
     changeSearchKeyword,
   } = useAutoComplete(communityKeywordData);
 
-  // TODO: 자동완성 컴포넌트 추상화하면서 거기로 넘기기
   const [isOpenDropdown, setIsOpenDropDown] = useState<boolean>(false);
+  const [keywordAssociations, setKeywordAssociations] = useState<
+    KeywordAssociationData[]
+  >([]);
 
   const getKeywordAssociations = async (keywordId: string) => {
     const keywordAssociationsData = await apis.getKeywordAssociations(
       keywordId,
     );
-    console.log(keywordAssociationsData);
+    const slicedData = keywordAssociationsData.slice(0, 3);
+    setKeywordAssociations(slicedData);
   };
 
   // TODO: 테스트코드 작성 가능
@@ -69,7 +74,6 @@ const KeywordAdder = ({ theme, addButtonValue }: KeywordAdderProps) => {
     e.preventDefault();
     setIsOpenDropDown(false);
     changeSearchKeyword('');
-
     const keywordId = getKeywordIdByKeyword(searchKeyword);
     if (keywordId) {
       await getKeywordAssociations(keywordId);
@@ -88,6 +92,12 @@ const KeywordAdder = ({ theme, addButtonValue }: KeywordAdderProps) => {
     const target = e.target as HTMLLIElement;
     changeSearchKeyword(target.innerText);
   };
+
+  // 이후 분리하여 상위 컴포넌트에서 사용 필요함.
+  // TODO: 전역상태관리 쓸지 물어보기
+  // useEffect(() => {
+  //   console.log(keywordAssociations);
+  // }, [keywordAssociations]);
 
   return (
     <div

--- a/frontend/components/community/KeywordAssociated.tsx
+++ b/frontend/components/community/KeywordAssociated.tsx
@@ -11,7 +11,7 @@ const KeywordAssociated = () => {
         src='/images/window-dog.png'
         width={66}
         height={70}
-        alt='추천 키워드를 알려주는 윈도우 도우미 강아지'
+        alt='추천 키워드를 알려주는 강아지 캐릭터'
       />
     </div>
   );

--- a/frontend/components/community/MyKeyword.tsx
+++ b/frontend/components/community/MyKeyword.tsx
@@ -1,15 +1,19 @@
+import { MouseEventHandler } from 'react';
 import styles from '@sass/components/community/MyKeyword.module.scss';
 import classnames from 'classnames/bind';
 const cx = classnames.bind(styles);
 interface MyKeywordProps {
+  handleDeleteClick: MouseEventHandler<HTMLButtonElement>;
   keyword: string;
 }
 
-const MyKeyword = ({ keyword }: MyKeywordProps) => {
+const MyKeyword = ({ keyword, handleDeleteClick }: MyKeywordProps) => {
   return (
     <li className={cx('keyword-item')}>
       {keyword}
-      <button className={cx('delete-button')}>x</button>
+      <button onClick={handleDeleteClick} className={cx('delete-button')}>
+        x
+      </button>
     </li>
   );
 };

--- a/frontend/components/community/SearchResultListLayout.tsx
+++ b/frontend/components/community/SearchResultListLayout.tsx
@@ -12,7 +12,7 @@ const SearchResultListLayout = ({
   children,
   layoutTheme,
 }: SearchResultListLayoutProps) => {
-  return <ul className={cx(`${layoutTheme}`)}>{children}</ul>;
+  return <ul className={cx(layoutTheme)}>{children}</ul>;
 };
 
 export default SearchResultListLayout;

--- a/frontend/config.ts
+++ b/frontend/config.ts
@@ -1,4 +1,4 @@
-const API_HOST = process.env.NEXT_PUBLIC_API_HOST;
+const API_HOST = process.env.NEXT_PUBLIC_NGINX_API_HOST;
 
 const config = {
   API_HOST,

--- a/frontend/constants/constants.ts
+++ b/frontend/constants/constants.ts
@@ -6,3 +6,7 @@ export enum ADMIN_PAGE_TAB {
 export enum KEYWORD_ADDER_THEME {
   MAIN = 'main',
 }
+
+export enum REACT_QUERY_KEY {
+  KEYWORD = 'keyword',
+}

--- a/frontend/constants/constants.ts
+++ b/frontend/constants/constants.ts
@@ -9,4 +9,5 @@ export enum KEYWORD_ADDER_THEME {
 
 export enum REACT_QUERY_KEY {
   KEYWORD = 'keyword',
+  USERME = 'userme',
 }

--- a/frontend/hooks/useAutoComplete.tsx
+++ b/frontend/hooks/useAutoComplete.tsx
@@ -7,7 +7,7 @@ const searchEngine = new TrieSearchEngine();
 
 // UI와 비즈니스 로직을 분리하기 위해서 여기에서는 dropDownList를 다루지 않음. 이것이 유의미한 분리가 가능할 것이라고 판단함.
 // useAutoComplete의 역할은 searchKeyword를 받아서 searchEngine을 통해 searchResult를 반환해주는 것
-const useAutoComplete = (keywordList: KeywordData[]) => {
+const useAutoComplete = (keywordList: KeywordData[] | undefined) => {
   const [searchKeyword, setSearchKeyword] = useState<string>('');
   const [searchResult, setSearchResult] = useState<string[]>(['']);
 
@@ -25,6 +25,9 @@ const useAutoComplete = (keywordList: KeywordData[]) => {
   // 키워드 리스트가 바뀔 때마다 searchEngine의 단어를 갱신한다.
   // TODO: 추가된 단어만 추가할 수 있도록 수정할 수 있을까? 현재 성능상의 이슈는 없어서 다른 작업이 먼저일듯함.
   useEffect(() => {
+    if (!keywordList) {
+      return;
+    }
     if (keywordList.length) {
       keywordList.forEach((keywordData) => {
         searchEngine.insert({

--- a/frontend/hooks/useAutoComplete.tsx
+++ b/frontend/hooks/useAutoComplete.tsx
@@ -16,12 +16,6 @@ const useAutoComplete = (keywordList: KeywordData[] | undefined) => {
     setSearchKeyword(value);
   };
 
-  const updateSearchResult = () => {
-    const searchEngineResult = searchEngine.search(searchKeyword);
-    setSearchResult(searchEngineResult);
-    setSearchKeyword('');
-  };
-
   // 키워드 리스트가 바뀔 때마다 searchEngine의 단어를 갱신한다.
   // TODO: 추가된 단어만 추가할 수 있도록 수정할 수 있을까? 현재 성능상의 이슈는 없어서 다른 작업이 먼저일듯함.
   useEffect(() => {
@@ -40,11 +34,15 @@ const useAutoComplete = (keywordList: KeywordData[] | undefined) => {
     }
   }, [keywordList]);
 
+  useEffect(() => {
+    const searchEngineResult = searchEngine.search(searchKeyword);
+    setSearchResult(searchEngineResult);
+  }, [searchKeyword]);
+
   return {
     searchKeyword,
     searchResult,
     changeSearchKeyword,
-    updateSearchResult,
   };
 };
 

--- a/frontend/hooks/useKeywordListQuery.tsx
+++ b/frontend/hooks/useKeywordListQuery.tsx
@@ -1,0 +1,23 @@
+import { REACT_QUERY_KEY } from '@constants/constants';
+import { useQuery } from '@tanstack/react-query';
+import apis from '../apis/apis';
+import { KeywordData } from '../types/types';
+
+// TS를 통해서 communityId가 들어오므로 useKeywordListFromCommuntyQuery라는 이름에서 간소화하였음. 추후 혼동이 생길 수 있으면 변경 가능.
+const useKeywordListQuery = (communityId: string) => {
+  const { data } = useQuery<KeywordData[]>(
+    [REACT_QUERY_KEY.KEYWORD, communityId],
+    () => {
+      const data = apis.getKeywords(communityId);
+      return data;
+    },
+    {
+      enabled: !!communityId,
+      refetchInterval: 1000,
+    },
+  );
+
+  return data;
+};
+
+export default useKeywordListQuery;

--- a/frontend/hooks/useUserKeywordList.tsx
+++ b/frontend/hooks/useUserKeywordList.tsx
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+import { KeywordData } from '../types/types';
+
+// 이렇게 관리해두면 React Query 연결할 때 편하지 않을까?
+// 어차피 React Query도 Hooks로 관리할테니 이 부분만 수정해주면 되어서 편할 것 같다.
+const useUserKeywordList = () => {
+  const [myKeywordList, setMyKeywordList] = useState<KeywordData[]>([]); // api 생기기 이전 임시로 작성
+  const [recentAssociationKeywordList, setRecentAssociationKeywordList] =
+    useState<KeywordData[]>([]); // api 생기기 이전 임시로 작성
+
+  // API 연결 이전 Mocking 데이터
+  const handleChangeMyKeywordList = (newList: KeywordData[]) => {
+    setMyKeywordList(newList);
+  };
+
+  // API 연결 이전 Mocking 데이터
+  // TODO: 변수명... 이거 맞아?
+  const handleChangeRecentAssociationKeywordList = (newList: KeywordData[]) => {
+    setRecentAssociationKeywordList(newList);
+  };
+
+  return {
+    myKeywordList,
+    recentAssociationKeywordList,
+    handleChangeMyKeywordList,
+    handleChangeRecentAssociationKeywordList,
+  };
+};
+
+export default useUserKeywordList;

--- a/frontend/hooks/useUserKeywordList.tsx
+++ b/frontend/hooks/useUserKeywordList.tsx
@@ -1,21 +1,23 @@
 import { useState } from 'react';
-import { KeywordData } from '../types/types';
+import { KeywordAssociationData, MyKeywordData } from '../types/types';
 
 // 이렇게 관리해두면 React Query 연결할 때 편하지 않을까?
 // 어차피 React Query도 Hooks로 관리할테니 이 부분만 수정해주면 되어서 편할 것 같다.
 const useUserKeywordList = () => {
-  const [myKeywordList, setMyKeywordList] = useState<KeywordData[]>([]); // api 생기기 이전 임시로 작성
+  const [myKeywordList, setMyKeywordList] = useState<MyKeywordData[]>([]); // api 생기기 이전 임시로 작성
   const [recentAssociationKeywordList, setRecentAssociationKeywordList] =
-    useState<KeywordData[]>([]); // api 생기기 이전 임시로 작성
+    useState<KeywordAssociationData[]>([]); // api 생기기 이전 임시로 작성
 
   // API 연결 이전 Mocking 데이터
-  const handleChangeMyKeywordList = (newList: KeywordData[]) => {
+  const handleChangeMyKeywordList = (newList: MyKeywordData[]) => {
     setMyKeywordList(newList);
   };
 
   // API 연결 이전 Mocking 데이터
   // TODO: 변수명... 이거 맞아?
-  const handleChangeRecentAssociationKeywordList = (newList: KeywordData[]) => {
+  const handleChangeRecentAssociationKeywordList = (
+    newList: KeywordAssociationData[],
+  ) => {
     setRecentAssociationKeywordList(newList);
   };
 

--- a/frontend/hooks/useUserKeywordList.tsx
+++ b/frontend/hooks/useUserKeywordList.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react';
-import { KeywordAssociationData, MyKeywordData } from '../types/types';
+import { KeywordRelatedData, MyKeywordData } from '../types/types';
 
 // 이렇게 관리해두면 React Query 연결할 때 편하지 않을까?
 // 어차피 React Query도 Hooks로 관리할테니 이 부분만 수정해주면 되어서 편할 것 같다.
 const useUserKeywordList = () => {
   const [myKeywordList, setMyKeywordList] = useState<MyKeywordData[]>([]); // api 생기기 이전 임시로 작성
-  const [recentAssociationKeywordList, setRecentAssociationKeywordList] =
-    useState<KeywordAssociationData[]>([]); // api 생기기 이전 임시로 작성
+  const [relatedKeywordList, setRelatedKeywordList] = useState<
+    KeywordRelatedData[]
+  >([]); // api 생기기 이전 임시로 작성
 
   // API 연결 이전 Mocking 데이터
   const handleChangeMyKeywordList = (newList: MyKeywordData[]) => {
@@ -14,18 +15,15 @@ const useUserKeywordList = () => {
   };
 
   // API 연결 이전 Mocking 데이터
-  // TODO: 변수명... 이거 맞아?
-  const handleChangeRecentAssociationKeywordList = (
-    newList: KeywordAssociationData[],
-  ) => {
-    setRecentAssociationKeywordList(newList);
+  const handleChangeRelatedKeywordList = (newList: KeywordRelatedData[]) => {
+    setRelatedKeywordList(newList);
   };
 
   return {
     myKeywordList,
-    recentAssociationKeywordList,
+    relatedKeywordList,
     handleChangeMyKeywordList,
-    handleChangeRecentAssociationKeywordList,
+    handleChangeRelatedKeywordList,
   };
 };
 

--- a/frontend/hooks/useUserMe.ts
+++ b/frontend/hooks/useUserMe.ts
@@ -5,7 +5,7 @@ import { UserData } from '../types/types';
 
 const useUserMe = () => {
   const fetchUserMe = async () => {
-    const data = await apis.getUserMe();
+    const data = await apis.getUserData();
     return data;
   };
   const { data } = useQuery<UserData>([REACT_QUERY_KEY.USERME], fetchUserMe);

--- a/frontend/hooks/useUserMe.ts
+++ b/frontend/hooks/useUserMe.ts
@@ -1,0 +1,16 @@
+import { REACT_QUERY_KEY } from '@constants/constants';
+import { useQuery } from '@tanstack/react-query';
+import apis from '../apis/apis';
+import { UserData } from '../types/types';
+
+const useUserMe = () => {
+  const fetchUserMe = async () => {
+    const data = await apis.getUserMe();
+    return data;
+  };
+  const { data } = useQuery<UserData>([REACT_QUERY_KEY.USERME], fetchUserMe);
+
+  return data;
+};
+
+export default useUserMe;

--- a/frontend/pages/community/[id].tsx
+++ b/frontend/pages/community/[id].tsx
@@ -8,10 +8,10 @@ import {
 import KeywordAdder from '@components/community/KeywordAdder';
 import AddCircleIcon from '@public/images/add-circle.svg';
 import { KEYWORD_ADDER_THEME } from '@constants/constants';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
+import useUserMe from '@hooks/useUserMe';
 
 const Community = () => {
-  const [userData, setUserData] = useState<string | null>('');
   const [isOpenLoginModal, setIsOpenLoginModal] = useState<boolean>(false);
   const [isOpenKeywordModal, setIsOpenKeywordModal] = useState<boolean>(false);
 
@@ -23,18 +23,10 @@ const Community = () => {
     setIsOpenKeywordModal(true);
   };
 
-  useEffect(() => {
-    const username = localStorage.getItem('waglewagle-username');
-    if (username) {
-      setUserData(username);
-    }
-  }, []);
-
   return (
     <CommunityLayout>
       <CommunityHeader
         title='부스트캠프 7기'
-        userData={userData}
         handleClickKeywordModal={handleClickKeywordModal}
         handleClickEnter={handleClickEnter}
       />

--- a/frontend/pages/community/[id].tsx
+++ b/frontend/pages/community/[id].tsx
@@ -6,6 +6,7 @@ import {
   KeywordBubbleChart,
 } from '@components/community';
 import KeywordAdder from '@components/community/KeywordAdder';
+import AddCircleIcon from '@public/images/add-circle.svg';
 import { KEYWORD_ADDER_THEME } from '@constants/constants';
 import { useState, useEffect } from 'react';
 
@@ -38,7 +39,10 @@ const Community = () => {
         handleClickEnter={handleClickEnter}
       />
       <KeywordBubbleChart />
-      <KeywordAdder theme={KEYWORD_ADDER_THEME.MAIN} />
+      <KeywordAdder
+        theme={KEYWORD_ADDER_THEME.MAIN}
+        addButtonValue={<AddCircleIcon />}
+      />
       <Modal
         isOpenModal={isOpenLoginModal}
         closeModal={() => setIsOpenLoginModal(false)}

--- a/frontend/pages/community/[id].tsx
+++ b/frontend/pages/community/[id].tsx
@@ -12,6 +12,7 @@ import { useState } from 'react';
 import useUserMe from '@hooks/useUserMe';
 
 const Community = () => {
+  const userData = useUserMe();
   const [isOpenLoginModal, setIsOpenLoginModal] = useState<boolean>(false);
   const [isOpenKeywordModal, setIsOpenKeywordModal] = useState<boolean>(false);
 
@@ -23,6 +24,10 @@ const Community = () => {
     setIsOpenKeywordModal(true);
   };
 
+  const closeLoginModal = () => {
+    setIsOpenLoginModal(false);
+  };
+
   return (
     <CommunityLayout>
       <CommunityHeader
@@ -31,15 +36,17 @@ const Community = () => {
         handleClickEnter={handleClickEnter}
       />
       <KeywordBubbleChart />
-      <KeywordAdder
-        theme={KEYWORD_ADDER_THEME.MAIN}
-        addButtonValue={<AddCircleIcon />}
-      />
+      {userData && (
+        <KeywordAdder
+          theme={KEYWORD_ADDER_THEME.MAIN}
+          addButtonValue={<AddCircleIcon />}
+        />
+      )}
       <Modal
         isOpenModal={isOpenLoginModal}
         closeModal={() => setIsOpenLoginModal(false)}
       >
-        <LoginModalContent />
+        <LoginModalContent closeLoginModal={closeLoginModal} />
       </Modal>
       <Modal
         isOpenModal={isOpenKeywordModal}

--- a/frontend/sass/components/common/LoginModalContent.module.scss
+++ b/frontend/sass/components/common/LoginModalContent.module.scss
@@ -19,18 +19,48 @@ $border-radius: 10px;
 
 .container {
   width: 400px;
+  height: 200px;
   padding: 10px;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   align-items: center;
+
+  hr {
+    width: 100%;
+  }
 }
 
 .title {
-  margin-bottom: 20px;
   text-align: center;
   font-size: 2.5rem;
   font-family: 'Nanum BugGeugSeong';
+}
+
+.username-login-form {
+  flex-direction: column;
+  @include flex-center;
+  gap: 20px;
+}
+
+.username-input {
+  width: 300px;
+  height: 40px;
+  border-radius: 5px;
+  text-align: center;
+  &::placeholder {
+    text-align: center;
+  }
+}
+
+.login-button {
+  width: 150px;
+  height: 40px;
+  border-radius: $border-radius;
+  background-color: $primary-color;
+  color: $off-white-color;
+
+  @include button-interaction;
 }
 
 .github-login-button {

--- a/frontend/sass/components/community/AutoCompleteFormLayout.module.scss
+++ b/frontend/sass/components/community/AutoCompleteFormLayout.module.scss
@@ -1,3 +1,12 @@
+@mixin button-interaction {
+  &:hover {
+    cursor: pointer;
+  }
+  &:active {
+    transform: scale(0.98);
+  }
+}
+
 // layoutTheme 추가가 필요한 경우, 새로운 class를 만들어서 input과 button 스타일을 지정해주면 됨.
 .main {
   position: relative;
@@ -21,5 +30,26 @@
     transition: all 0.2s;
     transform: translateY(-50%);
     cursor: pointer;
+  }
+}
+
+.modal {
+  display: flex;
+  gap: 10px;
+
+  input {
+    border: none;
+    border-bottom: 1px solid black;
+    font-family: 'Noto Sans';
+    &:focus {
+      outline: none;
+    }
+  }
+
+  button {
+    background-color: transparent;
+    border: none;
+    font-size: 1.5rem;
+    @include button-interaction;
   }
 }

--- a/frontend/sass/components/community/KeywordAddModal.module.scss
+++ b/frontend/sass/components/community/KeywordAddModal.module.scss
@@ -65,39 +65,6 @@
   flex-direction: column;
 }
 
-.keyword-add-form {
-  display: flex;
-  gap: 10px;
-}
-
-.keyword-add-input {
-  border: none;
-  border-bottom: 1px solid black;
-  &:focus {
-    outline: none;
-  }
-}
-
-.keyword-add-button {
-  background-color: transparent;
-  border: none;
-  font-size: 1.5rem;
-  @include button-interaction;
-}
-
-.search-result-list {
-  width: 100%;
-  height: 100px;
-  display: flex;
-  flex-direction: column;
-  align-self: flex-start;
-  margin-top: 10px;
-  padding: 10px;
-  overflow: auto;
-  border: 1px solid black;
-  border-radius: 10px;
-}
-
 .my-keyword-section {
   display: flex;
   flex-direction: column;

--- a/frontend/sass/components/community/KeywordAdderLayout.module.scss
+++ b/frontend/sass/components/community/KeywordAdderLayout.module.scss
@@ -1,9 +1,16 @@
 @import '@sass/variables.scss';
 
-.keyword-adder {
+.main {
   position: absolute;
   bottom: 100px;
   left: 50%;
   width: 250px;
   transform: translateX(-50%);
+}
+
+.modal {
+  width: 300px;
+  display: flex;
+  flex-direction: column-reverse;
+  align-items: center;
 }

--- a/frontend/sass/components/community/SearchResultListLayout.module.scss
+++ b/frontend/sass/components/community/SearchResultListLayout.module.scss
@@ -10,4 +10,31 @@
   border: 1px solid black;
   border-radius: 15px;
   font-size: 18px;
+
+  li:hover {
+    cursor: pointer;
+  }
+}
+
+.modal {
+  width: 100%;
+  height: 100px;
+  display: flex;
+  flex-direction: column;
+  align-self: flex-start;
+  gap: 5px;
+  margin-top: 10px;
+  padding: 10px;
+  overflow: auto;
+  border: 1px solid black;
+  border-radius: 10px;
+  font-size: 18px;
+  font-family: 'Noto Sans';
+
+  li {
+    padding: 0 5px;
+    &:hover {
+      cursor: pointer;
+    }
+  }
 }

--- a/frontend/types/types.ts
+++ b/frontend/types/types.ts
@@ -11,8 +11,23 @@ export type KeywordData = {
   memberCount: number;
 };
 
+export type AddKeywordData = {
+  keywordName: string;
+  communityId: string;
+};
+
+export type AddKeywordResponseData = {
+  keywordId: string;
+  keywordName: string;
+};
+
+export type JoinKeywordData = {
+  keywordId: string;
+  communityId: string;
+};
+
 // TODO: 그냥 rank를 옵셔널로 넣을까
-export type KeywordAssociationData = {
+export type KeywordRelatedData = {
   keywordId: string;
   keywordName: string;
   memberCount: number;

--- a/frontend/types/types.ts
+++ b/frontend/types/types.ts
@@ -6,6 +6,14 @@ export type KeywordData = {
   memberCount: number;
 };
 
+// TODO: 그냥 rank를 옵셔널로 넣을까
+export type KeywordAssociationData = {
+  keywordId: string;
+  keywordName: string;
+  memberCount: number;
+  rank: number;
+};
+
 export type BubbleData = {
   keyword: string;
   count: number;

--- a/frontend/types/types.ts
+++ b/frontend/types/types.ts
@@ -1,5 +1,10 @@
 import Circle from '../circlepacker/Circle';
 
+export type MyKeywordData = {
+  keywordId: string;
+  keywordName: string;
+};
+
 export type KeywordData = {
   keywordId: string;
   keywordName: string;
@@ -18,4 +23,10 @@ export type BubbleData = {
   keyword: string;
   count: number;
   circle: Circle;
+};
+
+export type UserData = {
+  userId: string;
+  username: string;
+  profileImageUrl: string | null;
 };

--- a/frontend/utils/getKeywordIdByKeywordName.ts
+++ b/frontend/utils/getKeywordIdByKeywordName.ts
@@ -1,0 +1,30 @@
+import { KeywordData } from '../types/types';
+
+// TODO: 테스트코드 작성 가능
+const getKeywordIdByKeyword = (
+  keyword: string,
+  communityKeywordData: KeywordData[] | undefined,
+): string | false => {
+  // 커뮤니티 키워드 데이터가 없으면 검색할 수 없다.
+  if (!communityKeywordData) {
+    return false;
+  }
+
+  // some을 쓰면 예외처리가 힘들 것 같아서 filter 사용
+  const result = communityKeywordData?.filter(
+    (keywordData) => keywordData.keywordName === keyword,
+  );
+
+  if (result.length === 0) {
+    return false;
+  }
+
+  if (result.length > 1) {
+    // TODO: 커스텀 에러 객체 만들기
+    throw new Error('중복된 id가 있습니다.');
+  }
+
+  return result[0].keywordId;
+};
+
+export default getKeywordIdByKeyword;


### PR DESCRIPTION
# 🏗️ 작업배경

- 앞서 진행한 리팩토링 결과물들을 통해서 커뮤니티 페이지의 키워드 추가로직과 키워드 추가 모달의 키워드 추가 로직을 하나의 컴포넌트로 통합시켰음.
- 이를 통해서 키워드 추가를 위한 컴포넌트만 다루면 키워드 추가 관련 API 작업이 가능해졌음.
- 키워드 추가 api는 아직 사용할 수 없어서 API를 연결해주기 위한 이벤트와 인터랙션만 만들어두기로 함.

# 💻 작업내용

https://user-images.githubusercontent.com/69471032/205114855-9e5034d3-1ed7-429f-a958-c11e680332da.mp4

- 키워드 자동완성 결과 리스트 클릭 상호작용을 구현
- 선택된 키워드 삭제 버튼 클릭 시 이벤트 구현
- 키워드 추가 키 입력과 제출 이벤트를 분리하여 자동완성 결과는 키 입력시 가져올 수 있도록 만듬.
- 현재 가지고 있는 커뮤니티 키워드 데이터에서 입력된 키워드를 통해 키워드 id를 가져올 수 있는 함수 구현
- 이를 통해서 키워드 추천 api 연결하여 수신 확인
- 유저 로그인 구현

# 🤔 고민사항

- 키워드 추천 api로 수신하면, 키워드 추가 컴포넌트로 결과가 수신됨.
- 이것을 상위 컴포넌트로 옮겨야하는데, 이 결과를 사용할 수 있는 곳이 많음. 차라리 '나의 키워드'나 '연관 키워드'는 전역 상태 관리를 통해서 관리하면 어떨까 생각됨.
연관 키워드는 키워드 id를 key값의 일부로 사용한 서버 상태로도 사용 가능하다고도 생각함.
=> 내일 논의해보기
현재 키워드 추가 시, 커뮤니티 페이지의 키워드 추가 입력창은 아무 이벤트가 없어도 되지만 키워드 추가 모달창은 여러 이벤트가 필요함. 키워드 추가 컴포넌트에게 callback을 추가할 수 있는 방법을 고민해보기