### PR TITLE
[Feat] GET 'user/me' API 반환값 수정

### DIFF
--- a/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUser.java
+++ b/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUser.java
@@ -11,6 +11,13 @@ import javax.persistence.*;
 import java.time.LocalDateTime;
 
 @Entity
+@Table(
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        columnNames = {"community_id", "user_id"}
+                )
+        }
+)
 @Getter
 @NoArgsConstructor
 public class CommunityUser {
@@ -24,9 +31,12 @@ public class CommunityUser {
     @ManyToOne(fetch = FetchType.LAZY)
     private User user;
 
+    //유저의 커뮤니티별 추가 특성(멀티 프로필, ...)
     private String ProfileImageUrl;
 
     private String communityUsername;
+
+    private Boolean isFirstVisit;
 
     @CreationTimestamp
     LocalDateTime createdAt;

--- a/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUserRepository.java
+++ b/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUserRepository.java
@@ -16,8 +16,8 @@ public class CommunityUserRepository {
         em.persist(communityUser);
     }
 
-    public CommunityUser findByUserIdCommunityId(Long userId, Long communityId) {
-        List<CommunityUser> communityUsers = em.createQuery("SELECT cu FROM CommunityUser cu WHERE cu.user.id = :userId AND cu.community.id = :communityId")
+    public CommunityUser findByUserIdAndCommunityId(Long userId, Long communityId) {
+        List<CommunityUser> communityUsers = em.createQuery("SELECT cu FROM CommunityUser cu WHERE cu.user.id = :userId AND cu.community.id = :communityId", CommunityUser.class)
                 .setParameter("userId", userId)
                 .setParameter("communityId", communityId)
                 .getResultList();

--- a/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUserService.java
+++ b/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUserService.java
@@ -18,7 +18,7 @@ public class CommunityUserService {
 
     @Transactional
     public boolean joinCommunity(Long userId, Long communityId) {
-        if (communityUserRepository.findByUserIdCommunityId(userId, communityId) != null) {
+        if (communityUserRepository.findByUserIdAndCommunityId(userId, communityId) != null) {
             System.out.println("Validated");
             return false;
         }

--- a/rest/src/main/java/com/waglewagle/rest/keyword/KeywordController.java
+++ b/rest/src/main/java/com/waglewagle/rest/keyword/KeywordController.java
@@ -98,7 +98,7 @@ public class KeywordController {
      * 11.29
      */
     @ResponseBody
-    @PostMapping("/disjoin")
+    @DeleteMapping("/disjoin")
     public ResponseEntity disjoinKeyword(
             @RequestBody DisjoinKeywordDTO disjoinKeywordDTO,
             @CookieValue("user_id") Long userId) {

--- a/rest/src/main/java/com/waglewagle/rest/user/UserController.java
+++ b/rest/src/main/java/com/waglewagle/rest/user/UserController.java
@@ -10,6 +10,8 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
 import java.util.*;
 
+import static com.waglewagle.rest.user.dto.UserInfoDTO.*;
+
 @Controller
 @RequestMapping("/api/v1/user")
 @RequiredArgsConstructor
@@ -52,8 +54,10 @@ public class UserController {
 
     @GetMapping("/me")
     @ResponseBody
-    public ResponseEntity<UserInfoDTO> getUserInfo(@CookieValue(name = "user_id") Long userId) {
-        UserInfoDTO userInfoDTO = userService.getUserInfo(userId);
+    public ResponseEntity<UserInfoResDTO> getUserInfo(@CookieValue(name = "user_id") Long userId,
+                                                      @RequestParam("community-id") Long communityId) {
+
+        UserInfoResDTO userInfoDTO = userService.getUserInfo(userId, communityId);
 
         return ResponseEntity.ok(userInfoDTO);
     }

--- a/rest/src/main/java/com/waglewagle/rest/user/UserService.java
+++ b/rest/src/main/java/com/waglewagle/rest/user/UserService.java
@@ -1,5 +1,7 @@
 package com.waglewagle.rest.user;
 
+import com.waglewagle.rest.communityUser.CommunityUser;
+import com.waglewagle.rest.communityUser.CommunityUserRepository;
 import com.waglewagle.rest.keywordUser.KeywordUser;
 import com.waglewagle.rest.user.dto.UpdateProfileDTO;
 import com.waglewagle.rest.user.dto.UserInfoDTO;
@@ -12,11 +14,14 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import static com.waglewagle.rest.user.dto.UserInfoDTO.*;
+
 @Service
 @RequiredArgsConstructor
 public class UserService {
 
     private final UserRepository userRepository;
+    private final CommunityUserRepository communityUserRepository;
 
     @Transactional
     public Long authenticateWithUsername(String username) {
@@ -55,13 +60,17 @@ public class UserService {
         return user;
     }
 
-    public UserInfoDTO getUserInfo(Long userId) {
+    @Transactional
+    public UserInfoResDTO getUserInfo(Long userId, Long communityId) {
         User user = userRepository.findById(userId);
+        CommunityUser communityUser = communityUserRepository.findByUserIdAndCommunityId(userId, communityId);
+
+        //TODO: null에 대한 Http 'Bad Request(or No Content?)'처리가 필요함(지금은 Conroller에서 Http.ok(200)에 null만 태워서 보냄)
         if (Objects.isNull(user)) {
             return null;
         }
 
-        return new UserInfoDTO(user);
+        return new UserInfoResDTO(user, communityUser);
     }
 
     public List<KeywordUser> getUserKeywords(Long userId) {

--- a/rest/src/main/java/com/waglewagle/rest/user/dto/UserInfoDTO.java
+++ b/rest/src/main/java/com/waglewagle/rest/user/dto/UserInfoDTO.java
@@ -1,19 +1,26 @@
 package com.waglewagle.rest.user.dto;
 
+import com.waglewagle.rest.communityUser.CommunityUser;
+import com.waglewagle.rest.user.Role;
 import com.waglewagle.rest.user.User;
 import lombok.Getter;
 
-@Getter
 public class UserInfoDTO {
 
-    public UserInfoDTO(User user) {
-        userId = user.getId().toString();
-        username= user.getUsername();
-        profileImageUrl = user.getProfileImageUrl();
+    @Getter
+    public static class UserInfoResDTO {
+        private String userId;
+        private String username;
+        private String profileImageUrl;
+        private Role role;
+        private Boolean isFirstInCommunity;
 
+        public UserInfoResDTO (User user, CommunityUser communityUser) {
+            this.userId = String.valueOf(user.getId());
+            this.username = user.getUsername();
+            this.profileImageUrl = user.getProfileImageUrl();
+            this.role = user.getRole();
+            this.isFirstInCommunity = communityUser.getIsFirstVisit();
+        }
     }
-
-    private String userId;
-    private String username;
-    private String profileImageUrl;
 }


### PR DESCRIPTION
## 작업 결과물
```
GET '/api/v1/user/me'

Query Params
community-id : string(?community-id=1 과 같이 보내주셔야 합니다. ?community-id="1" 안되요.)

Response Body
{
  userId: string,
  username: string,
  profileImageUrl: string,
  role: string,
  isFirstInCommunity: boolean
}
```

## 작업 배경 
- 2022.12.02
초기 로그인인지 확인할 수 없어서, 키워드 입력 모달을 띄울 수 없습니다.
user/me response body에 초기 로그인인지 확인할 수 있는 정보가 필요합니다.

- 2022.12.02
관리자 페이지 접근 권한을 막기 위해 /user/me에 role도 같이 와야합니다.

## 작업 내용
1. `CommunityUser` Table에 `isFirstVisit` boolean 컬럼을 추가하였음.
2. `userId` 와 `communityId` 를 통해 조회
3. `CommunityUser` Table : `userId` 컬럼과 `communityId` 컬럼의 조합을 유니크 키로 등록하였음.
    - 이후 쿼리 실행계획에서 인덱스가 잘 작동하는지 확인할 예정

## 다음 작업
- ⚠️ 유저가 커뮤니티에 가입할 때, `isFirstInCommunity` 칼럼에 `false` 가 들어가도록 수정하여야 함. @aaa22220304 
- `CommunityUser` Table의 `isFirstInCommunity`값을 변경할 수 있는 API, PUT '/user/first-visit'(가제) 구현 예정