### PR TITLE
[feat] 커뮤니티 최초 가입 컬럼 및 변경 API, 커뮤니티 프로필 변경 API 추가

### DIFF
--- a/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUser.java
+++ b/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUser.java
@@ -50,7 +50,7 @@ public class CommunityUser {
     public CommunityUser (User user, Community community) {
         this.user = user;
         this.community = community;
-        isFirstVisit = false;
+        isFirstVisit = true;
     }
 
     public void updateProfile(UpdateCommunityProfileInputDTO updateCommunityProfileInputDTO) {

--- a/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUser.java
+++ b/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUser.java
@@ -1,6 +1,7 @@
 package com.waglewagle.rest.communityUser;
 
 import com.waglewagle.rest.community.Community;
+import com.waglewagle.rest.communityUser.CommunityUserDTO.UpdateCommunityProfileInputDTO;
 import com.waglewagle.rest.user.User;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -50,5 +51,10 @@ public class CommunityUser {
         this.user = user;
         this.community = community;
         isFirstVisit = false;
+    }
+
+    public void updateProfile(UpdateCommunityProfileInputDTO updateCommunityProfileInputDTO) {
+        communityUsername = updateCommunityProfileInputDTO.getUsername();
+        profileImageUrl = updateCommunityProfileInputDTO.getProfileImageUrl();
     }
 }

--- a/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUser.java
+++ b/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUser.java
@@ -32,7 +32,7 @@ public class CommunityUser {
     private User user;
 
     //유저의 커뮤니티별 추가 특성(멀티 프로필, ...)
-    private String ProfileImageUrl;
+    private String profileImageUrl;
 
     private String communityUsername;
 
@@ -49,5 +49,6 @@ public class CommunityUser {
     public CommunityUser (User user, Community community) {
         this.user = user;
         this.community = community;
+        isFirstVisit = false;
     }
 }

--- a/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUser.java
+++ b/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUser.java
@@ -57,4 +57,8 @@ public class CommunityUser {
         communityUsername = updateCommunityProfileInputDTO.getUsername();
         profileImageUrl = updateCommunityProfileInputDTO.getProfileImageUrl();
     }
+
+    public void updateIsFirstVisit() {
+            isFirstVisit = false;
+    }
 }

--- a/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUserController.java
+++ b/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUserController.java
@@ -7,6 +7,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
+import javax.websocket.server.PathParam;
+
 
 @Controller
 @RequestMapping("/api/v1/community-user")
@@ -49,6 +51,22 @@ public class CommunityUserController {
 
         communityUserService.updateCommunityUserProfile(updateCommunityProfileInputDTO, communityId, userId);
 
+
+        return new ResponseEntity(null, HttpStatus.OK);
+    }
+
+    @PutMapping("{community_id}/first-visit")
+    public ResponseEntity updateIsFirstVisit(@PathVariable("community_id") Long communityId,
+                                             @CookieValue("user_id") Long userId) {
+
+        if (!communityUserService.isAlreadyJoined(userId, communityId)) {
+            return new ResponseEntity(null, HttpStatus.BAD_REQUEST);
+        }
+        if (!communityUserService.isFirstVisit(userId, communityId)) {
+            return new ResponseEntity(null, HttpStatus.BAD_REQUEST);
+        }
+
+        communityUserService.updateIsFirstVisit(userId, communityId);
 
         return new ResponseEntity(null, HttpStatus.OK);
     }

--- a/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUserController.java
+++ b/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUserController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class CommunityUserController {
 
-        private final CommunityUserService communityUserService;
+    private final CommunityUserService communityUserService;
 
     /**
      * 커뮤니티 가입하기
@@ -21,14 +21,36 @@ public class CommunityUserController {
      */
     @PostMapping("")
     public ResponseEntity joinCommunity(@RequestBody JoinCommunityInputDTO joinCommunityInputDTO, @CookieValue("user_id") Long userId) {
-            Long communityId = Long.parseLong(joinCommunityInputDTO.getCommunityId());
+        Long communityId = Long.parseLong(joinCommunityInputDTO.getCommunityId());
 
         if (communityUserService.isAlreadyJoined(userId, communityId)) {
-                return new ResponseEntity(null, HttpStatus.BAD_REQUEST);
-            }
+            return new ResponseEntity(null, HttpStatus.BAD_REQUEST);
+        }
 
         communityUserService.joinCommunity(userId, communityId);
 
-            return new ResponseEntity(null, HttpStatus.CREATED);
+        return new ResponseEntity(null, HttpStatus.CREATED);
+    }
+
+    /**
+     * 커뮤니티 프로필 수정하기
+     */
+    @PutMapping("/{community_id}/profile")
+    public ResponseEntity updateCommunityUserProfile(@RequestBody UpdateCommunityProfileInputDTO updateCommunityProfileInputDTO,
+                                                 @PathVariable("community_id") Long communityId,
+                                                 @CookieValue("user_id") Long userId) {
+
+        if (updateCommunityProfileInputDTO.isEmpty()) {
+            return new ResponseEntity(null, HttpStatus.BAD_REQUEST);
         }
+        if (!communityUserService.isAlreadyJoined(userId, communityId)) {
+            return new ResponseEntity(null, HttpStatus.BAD_REQUEST);
+        }
+
+        communityUserService.updateCommunityUserProfile(updateCommunityProfileInputDTO, communityId, userId);
+
+
+        return new ResponseEntity(null, HttpStatus.OK);
+    }
+
 }

--- a/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUserController.java
+++ b/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUserController.java
@@ -5,10 +5,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
+
 
 @Controller
 @RequestMapping("/api/v1/community-user")
@@ -25,9 +23,11 @@ public class CommunityUserController {
     public ResponseEntity joinCommunity(@RequestBody JoinCommunityInputDTO joinCommunityInputDTO, @CookieValue("user_id") Long userId) {
             Long communityId = Long.parseLong(joinCommunityInputDTO.getCommunityId());
 
-            if (!communityUserService.joinCommunity(userId, communityId)) {
+        if (communityUserService.isAlreadyJoined(userId, communityId)) {
                 return new ResponseEntity(null, HttpStatus.BAD_REQUEST);
             }
+
+        communityUserService.joinCommunity(userId, communityId);
 
             return new ResponseEntity(null, HttpStatus.CREATED);
         }

--- a/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUserDTO.java
+++ b/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUserDTO.java
@@ -11,4 +11,17 @@ public class CommunityUserDTO {
 
         private String communityId;
     }
+
+    @Getter
+    @Setter
+    public static class UpdateCommunityProfileInputDTO {
+
+        private String profileImageUrl;
+        private String username;
+
+
+        public boolean isEmpty() {
+            return profileImageUrl == null && username == null;
+        }
+    }
 }

--- a/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUserService.java
+++ b/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUserService.java
@@ -39,4 +39,15 @@ public class CommunityUserService {
         CommunityUser communityUser = communityUserRepository.findByUserIdAndCommunityId(userId, communityId);
         communityUser.updateProfile(updateCommunityProfileInputDTO);
     }
+
+    @Transactional
+    public boolean isFirstVisit(Long userId, Long communityId) {
+        return communityUserRepository.findByUserIdAndCommunityId(userId, communityId).getIsFirstVisit();
+    }
+
+    @Transactional
+    public void updateIsFirstVisit(Long userId, Long communityId) {
+        CommunityUser communityUser = communityUserRepository.findByUserIdAndCommunityId(userId, communityId);
+        communityUser.updateIsFirstVisit();
+    }
 }

--- a/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUserService.java
+++ b/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUserService.java
@@ -16,19 +16,22 @@ public class CommunityUserService {
     private final CommunityRepository communityRepository;
     private final UserRepository userRepository;
 
+
     @Transactional
-    public boolean joinCommunity(Long userId, Long communityId) {
-        if (communityUserRepository.findByUserIdAndCommunityId(userId, communityId) != null) {
-            System.out.println("Validated");
-            return false;
+    public boolean isAlreadyJoined(Long userId, Long communityId) {
+        return communityUserRepository.findByUserIdAndCommunityId(userId, communityId) != null;
         }
+
+
+    @Transactional
+    public void joinCommunity(Long userId, Long communityId) {
 
         User user = userRepository.findById(userId);
         Community community = communityRepository.findOneById(communityId);
         CommunityUser communityUser = new CommunityUser(user, community);
 
         communityUserRepository.save(communityUser);
-        return true;
+    }
 
     }
 }

--- a/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUserService.java
+++ b/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUserService.java
@@ -2,6 +2,7 @@ package com.waglewagle.rest.communityUser;
 
 import com.waglewagle.rest.community.CommunityRepository;
 import com.waglewagle.rest.community.Community;
+import com.waglewagle.rest.communityUser.CommunityUserDTO.*;
 import com.waglewagle.rest.user.User;
 import com.waglewagle.rest.user.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +21,7 @@ public class CommunityUserService {
     @Transactional
     public boolean isAlreadyJoined(Long userId, Long communityId) {
         return communityUserRepository.findByUserIdAndCommunityId(userId, communityId) != null;
-        }
+    }
 
 
     @Transactional
@@ -33,5 +34,9 @@ public class CommunityUserService {
         communityUserRepository.save(communityUser);
     }
 
+    @Transactional
+    public void updateCommunityUserProfile(UpdateCommunityProfileInputDTO updateCommunityProfileInputDTO, Long communityId, Long userId) {
+        CommunityUser communityUser = communityUserRepository.findByUserIdAndCommunityId(userId, communityId);
+        communityUser.updateProfile(updateCommunityProfileInputDTO);
     }
 }


### PR DESCRIPTION
## 작업 결과물
```
PUT

/api/v1/community-user/{community_id}/profile

Request: 
- 인증 쿠키(user-id), 
- {
  profileImageUrl: string
  username: string
}

Response:
- 성공: status code 200
- 실패: status code 400
```
```
PUT

/api/v1/community-user/123/first-visit

Request:
- 인증 쿠키(user-id)

Response:
- 성공: status code 200
- 실패: status code 400
```

## 작업 내용
- community_user 테이블 is_first_visit 컬럼 추가
  - 최초 가입 시 true로 설정
  - API 요청으로 false로 설정
- 커뮤니티 프로필 변경 API
  - 각 필드에 null이 있다면, null로 변경됨.

## 다음 예정 작업
- keyword 도메인
  - `GET` /api/v1/keyword/user/{community_id}
  - 커뮤니티 내 내가 가진 키워드