### PR TITLE
[feat] 커뮤니티 내 내가 선택한 키워드 API 및 키워드 추천 API 반환 개수 수정

### DIFF
--- a/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUser.java
+++ b/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUser.java
@@ -50,7 +50,7 @@ public class CommunityUser {
     public CommunityUser (User user, Community community) {
         this.user = user;
         this.community = community;
-        isFirstVisit = false;
+        isFirstVisit = true;
     }
 
     public void updateProfile(UpdateCommunityProfileInputDTO updateCommunityProfileInputDTO) {

--- a/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUser.java
+++ b/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUser.java
@@ -1,6 +1,7 @@
 package com.waglewagle.rest.communityUser;
 
 import com.waglewagle.rest.community.Community;
+import com.waglewagle.rest.communityUser.CommunityUserDTO.UpdateCommunityProfileInputDTO;
 import com.waglewagle.rest.user.User;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -50,5 +51,10 @@ public class CommunityUser {
         this.user = user;
         this.community = community;
         isFirstVisit = false;
+    }
+
+    public void updateProfile(UpdateCommunityProfileInputDTO updateCommunityProfileInputDTO) {
+        communityUsername = updateCommunityProfileInputDTO.getUsername();
+        profileImageUrl = updateCommunityProfileInputDTO.getProfileImageUrl();
     }
 }

--- a/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUser.java
+++ b/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUser.java
@@ -32,7 +32,7 @@ public class CommunityUser {
     private User user;
 
     //유저의 커뮤니티별 추가 특성(멀티 프로필, ...)
-    private String ProfileImageUrl;
+    private String profileImageUrl;
 
     private String communityUsername;
 
@@ -49,5 +49,6 @@ public class CommunityUser {
     public CommunityUser (User user, Community community) {
         this.user = user;
         this.community = community;
+        isFirstVisit = false;
     }
 }

--- a/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUser.java
+++ b/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUser.java
@@ -57,4 +57,8 @@ public class CommunityUser {
         communityUsername = updateCommunityProfileInputDTO.getUsername();
         profileImageUrl = updateCommunityProfileInputDTO.getProfileImageUrl();
     }
+
+    public void updateIsFirstVisit() {
+            isFirstVisit = false;
+    }
 }

--- a/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUserController.java
+++ b/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUserController.java
@@ -7,6 +7,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
+import javax.websocket.server.PathParam;
+
 
 @Controller
 @RequestMapping("/api/v1/community-user")
@@ -49,6 +51,22 @@ public class CommunityUserController {
 
         communityUserService.updateCommunityUserProfile(updateCommunityProfileInputDTO, communityId, userId);
 
+
+        return new ResponseEntity(null, HttpStatus.OK);
+    }
+
+    @PutMapping("{community_id}/first-visit")
+    public ResponseEntity updateIsFirstVisit(@PathVariable("community_id") Long communityId,
+                                             @CookieValue("user_id") Long userId) {
+
+        if (!communityUserService.isAlreadyJoined(userId, communityId)) {
+            return new ResponseEntity(null, HttpStatus.BAD_REQUEST);
+        }
+        if (!communityUserService.isFirstVisit(userId, communityId)) {
+            return new ResponseEntity(null, HttpStatus.BAD_REQUEST);
+        }
+
+        communityUserService.updateIsFirstVisit(userId, communityId);
 
         return new ResponseEntity(null, HttpStatus.OK);
     }

--- a/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUserController.java
+++ b/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUserController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class CommunityUserController {
 
-        private final CommunityUserService communityUserService;
+    private final CommunityUserService communityUserService;
 
     /**
      * 커뮤니티 가입하기
@@ -21,14 +21,36 @@ public class CommunityUserController {
      */
     @PostMapping("")
     public ResponseEntity joinCommunity(@RequestBody JoinCommunityInputDTO joinCommunityInputDTO, @CookieValue("user_id") Long userId) {
-            Long communityId = Long.parseLong(joinCommunityInputDTO.getCommunityId());
+        Long communityId = Long.parseLong(joinCommunityInputDTO.getCommunityId());
 
         if (communityUserService.isAlreadyJoined(userId, communityId)) {
-                return new ResponseEntity(null, HttpStatus.BAD_REQUEST);
-            }
+            return new ResponseEntity(null, HttpStatus.BAD_REQUEST);
+        }
 
         communityUserService.joinCommunity(userId, communityId);
 
-            return new ResponseEntity(null, HttpStatus.CREATED);
+        return new ResponseEntity(null, HttpStatus.CREATED);
+    }
+
+    /**
+     * 커뮤니티 프로필 수정하기
+     */
+    @PutMapping("/{community_id}/profile")
+    public ResponseEntity updateCommunityUserProfile(@RequestBody UpdateCommunityProfileInputDTO updateCommunityProfileInputDTO,
+                                                 @PathVariable("community_id") Long communityId,
+                                                 @CookieValue("user_id") Long userId) {
+
+        if (updateCommunityProfileInputDTO.isEmpty()) {
+            return new ResponseEntity(null, HttpStatus.BAD_REQUEST);
         }
+        if (!communityUserService.isAlreadyJoined(userId, communityId)) {
+            return new ResponseEntity(null, HttpStatus.BAD_REQUEST);
+        }
+
+        communityUserService.updateCommunityUserProfile(updateCommunityProfileInputDTO, communityId, userId);
+
+
+        return new ResponseEntity(null, HttpStatus.OK);
+    }
+
 }

--- a/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUserController.java
+++ b/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUserController.java
@@ -5,10 +5,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
+
 
 @Controller
 @RequestMapping("/api/v1/community-user")
@@ -25,9 +23,11 @@ public class CommunityUserController {
     public ResponseEntity joinCommunity(@RequestBody JoinCommunityInputDTO joinCommunityInputDTO, @CookieValue("user_id") Long userId) {
             Long communityId = Long.parseLong(joinCommunityInputDTO.getCommunityId());
 
-            if (!communityUserService.joinCommunity(userId, communityId)) {
+        if (communityUserService.isAlreadyJoined(userId, communityId)) {
                 return new ResponseEntity(null, HttpStatus.BAD_REQUEST);
             }
+
+        communityUserService.joinCommunity(userId, communityId);
 
             return new ResponseEntity(null, HttpStatus.CREATED);
         }

--- a/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUserDTO.java
+++ b/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUserDTO.java
@@ -11,4 +11,17 @@ public class CommunityUserDTO {
 
         private String communityId;
     }
+
+    @Getter
+    @Setter
+    public static class UpdateCommunityProfileInputDTO {
+
+        private String profileImageUrl;
+        private String username;
+
+
+        public boolean isEmpty() {
+            return profileImageUrl == null && username == null;
+        }
+    }
 }

--- a/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUserService.java
+++ b/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUserService.java
@@ -39,4 +39,15 @@ public class CommunityUserService {
         CommunityUser communityUser = communityUserRepository.findByUserIdAndCommunityId(userId, communityId);
         communityUser.updateProfile(updateCommunityProfileInputDTO);
     }
+
+    @Transactional
+    public boolean isFirstVisit(Long userId, Long communityId) {
+        return communityUserRepository.findByUserIdAndCommunityId(userId, communityId).getIsFirstVisit();
+    }
+
+    @Transactional
+    public void updateIsFirstVisit(Long userId, Long communityId) {
+        CommunityUser communityUser = communityUserRepository.findByUserIdAndCommunityId(userId, communityId);
+        communityUser.updateIsFirstVisit();
+    }
 }

--- a/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUserService.java
+++ b/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUserService.java
@@ -16,19 +16,22 @@ public class CommunityUserService {
     private final CommunityRepository communityRepository;
     private final UserRepository userRepository;
 
+
     @Transactional
-    public boolean joinCommunity(Long userId, Long communityId) {
-        if (communityUserRepository.findByUserIdAndCommunityId(userId, communityId) != null) {
-            System.out.println("Validated");
-            return false;
+    public boolean isAlreadyJoined(Long userId, Long communityId) {
+        return communityUserRepository.findByUserIdAndCommunityId(userId, communityId) != null;
         }
+
+
+    @Transactional
+    public void joinCommunity(Long userId, Long communityId) {
 
         User user = userRepository.findById(userId);
         Community community = communityRepository.findOneById(communityId);
         CommunityUser communityUser = new CommunityUser(user, community);
 
         communityUserRepository.save(communityUser);
-        return true;
+    }
 
     }
 }

--- a/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUserService.java
+++ b/rest/src/main/java/com/waglewagle/rest/communityUser/CommunityUserService.java
@@ -2,6 +2,7 @@ package com.waglewagle.rest.communityUser;
 
 import com.waglewagle.rest.community.CommunityRepository;
 import com.waglewagle.rest.community.Community;
+import com.waglewagle.rest.communityUser.CommunityUserDTO.*;
 import com.waglewagle.rest.user.User;
 import com.waglewagle.rest.user.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +21,7 @@ public class CommunityUserService {
     @Transactional
     public boolean isAlreadyJoined(Long userId, Long communityId) {
         return communityUserRepository.findByUserIdAndCommunityId(userId, communityId) != null;
-        }
+    }
 
 
     @Transactional
@@ -33,5 +34,9 @@ public class CommunityUserService {
         communityUserRepository.save(communityUser);
     }
 
+    @Transactional
+    public void updateCommunityUserProfile(UpdateCommunityProfileInputDTO updateCommunityProfileInputDTO, Long communityId, Long userId) {
+        CommunityUser communityUser = communityUserRepository.findByUserIdAndCommunityId(userId, communityId);
+        communityUser.updateProfile(updateCommunityProfileInputDTO);
     }
 }

--- a/rest/src/main/java/com/waglewagle/rest/keyword/KeywordController.java
+++ b/rest/src/main/java/com/waglewagle/rest/keyword/KeywordController.java
@@ -1,19 +1,16 @@
 package com.waglewagle.rest.keyword;
 
 import com.waglewagle.rest.community.CommunityService;
+import com.waglewagle.rest.communityUser.CommunityUserService;
 import com.waglewagle.rest.keyword.KeywordDTO.*;
 import com.waglewagle.rest.keyword.association.AssociationDTO;
-import com.waglewagle.rest.keywordUser.KeywordUserRepository;
 import com.waglewagle.rest.keywordUser.KeywordUserService;
 import lombok.RequiredArgsConstructor;
-import lombok.ToString;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Controller
@@ -24,6 +21,7 @@ public class KeywordController {
     private final KeywordService keywordService;
     private final CommunityService communityService;
     private final KeywordUserService keywordUserService;
+    private final CommunityUserService communityUserService;
 
     /**
      * 키워드 생성
@@ -31,7 +29,7 @@ public class KeywordController {
      */
     @ResponseBody
     @PostMapping("")
-    public ResponseEntity<CreateKeywordResponse> createKeyword(@RequestBody CreateKeywordInputDTO createKeywordInputDTO, @CookieValue("user_id") Long userId) {
+    public ResponseEntity<KeywordResponseDTO> createKeyword(@RequestBody CreateKeywordInputDTO createKeywordInputDTO, @CookieValue("user_id") Long userId) {
 
         if (keywordService.isDuplicated(createKeywordInputDTO)) {
             return new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);
@@ -42,7 +40,7 @@ public class KeywordController {
 
         Keyword keyword = keywordService.createKeyword(userId, communityId, keywordName);
 
-        return new ResponseEntity<>(new KeywordDTO.CreateKeywordResponse(keyword), HttpStatus.CREATED);
+        return new ResponseEntity<>(new KeywordResponseDTO(keyword), HttpStatus.CREATED);
     }
 
     //spring controller parameter
@@ -106,5 +104,23 @@ public class KeywordController {
         keywordUserService.disjoinKeyword(disjoinKeywordDTO, userId);
 
         return ResponseEntity.ok(null);
+    }
+
+    @GetMapping("/user/{community_id}")
+    public ResponseEntity getJoinedKeywords (@PathVariable("community_id") Long communityId,
+                               @CookieValue("user_id") Long userId) {
+        if (!communityUserService.isAlreadyJoined(userId, communityId)) {
+            // 참여하지 않은 커뮤니티의 키워드를 요청했다.
+            // not found?
+            // unauthorized?
+            // bad request?
+            return new ResponseEntity(null, HttpStatus.BAD_REQUEST);
+        }
+
+        List<KeywordResponseDTO> keywordResponseDTODTOS = keywordService.getJoinedKeywords(userId, communityId);
+
+
+        return new ResponseEntity(keywordResponseDTODTOS, HttpStatus.OK);
+
     }
 }

--- a/rest/src/main/java/com/waglewagle/rest/keyword/KeywordController.java
+++ b/rest/src/main/java/com/waglewagle/rest/keyword/KeywordController.java
@@ -11,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Controller
@@ -64,16 +65,16 @@ public class KeywordController {
         // TODO: Exception Handler
         // return type이 정해져 있어 가에러 메시지를 string이나 객체로 만들 수 없음.
         if (!communityService.isExistCommunity(communityId)) {
-            return ResponseEntity.badRequest().build();
+            return new ResponseEntity(null, HttpStatus.BAD_REQUEST);
         }
 
         List<KeywordDTO> keywordListInCommunity = keywordService.getKeywordListInCommunity(communityId);
 
         if (keywordListInCommunity.isEmpty()) {
-            return ResponseEntity.noContent().build();
+            return new ResponseEntity(new ArrayList<>(), HttpStatus.NO_CONTENT);
         }
 
-        return ResponseEntity.ok(keywordListInCommunity);
+        return new ResponseEntity(keywordListInCommunity, HttpStatus.OK);
     }
 
     /**

--- a/rest/src/main/java/com/waglewagle/rest/keyword/KeywordDTO.java
+++ b/rest/src/main/java/com/waglewagle/rest/keyword/KeywordDTO.java
@@ -4,6 +4,9 @@ import com.waglewagle.rest.community.Community;
 import com.waglewagle.rest.user.User;
 import lombok.*;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Getter
 @ToString
 @AllArgsConstructor
@@ -74,18 +77,6 @@ public class KeywordDTO {
     }
 
     @Getter
-    public static class CreateKeywordResponse {
-
-        private final String keywordId;
-        private final String keywordName;
-
-        CreateKeywordResponse(Keyword keyword) {
-            keywordId = String.valueOf(keyword.getId());
-            keywordName = keyword.getKeyword();
-        }
-    }
-
-    @Getter
     @NoArgsConstructor
     public static class CreateKeywordDTO {
 
@@ -101,6 +92,22 @@ public class KeywordDTO {
             this.author = author;
             this.community = community;
             this.keywordName = keywordName;
+        }
+    }
+
+    @Getter
+    public static class KeywordResponseDTO {
+
+        private final String keywordId;
+        private final String keywordName;
+
+        public KeywordResponseDTO(Keyword keyword) {
+            keywordId = String.valueOf(keyword.getId());
+            keywordName = keyword.getKeyword();
+        }
+
+        static List<KeywordResponseDTO> createKeywordResponses(List<Keyword> keywords) {
+            return keywords.stream().map(keyword -> new KeywordResponseDTO(keyword)).collect(Collectors.toList());
         }
     }
 }

--- a/rest/src/main/java/com/waglewagle/rest/keyword/KeywordRepository.java
+++ b/rest/src/main/java/com/waglewagle/rest/keyword/KeywordRepository.java
@@ -30,7 +30,9 @@ public class KeywordRepository {
         return jpaQueryFactory
                 .selectFrom(keyword1)
                 .innerJoin(keyword1.community, community)
+                .innerJoin(keyword1.keywordUsers, keywordUser)
                 .where(community.id.eq(communityId))
+                .fetchJoin()
                 .fetch(); //TODO: fetchJoin?
     }
 

--- a/rest/src/main/java/com/waglewagle/rest/keyword/KeywordRepository.java
+++ b/rest/src/main/java/com/waglewagle/rest/keyword/KeywordRepository.java
@@ -2,7 +2,6 @@ package com.waglewagle.rest.keyword;
 
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.waglewagle.rest.community.Community;
 import com.waglewagle.rest.keyword.KeywordDTO.*;
 import com.waglewagle.rest.user.QUser;
 import lombok.RequiredArgsConstructor;
@@ -61,5 +60,14 @@ public class KeywordRepository {
     public void saveKeyword(Keyword keyword) {
         em.persist(keyword);
 //        return keyword;
+    }
+
+    public List<Keyword> getJoinedKeywords(Long userId, Long communityId) {
+        return jpaQueryFactory
+                .select(keywordUser.keyword)
+                .from(keywordUser)
+                .where(keywordUser.user.id.eq(userId))
+                .where(keywordUser.community.id.eq(communityId))
+                .fetch();
     }
 }

--- a/rest/src/main/java/com/waglewagle/rest/keyword/KeywordService.java
+++ b/rest/src/main/java/com/waglewagle/rest/keyword/KeywordService.java
@@ -12,8 +12,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -45,20 +45,15 @@ public class KeywordService {
     public List<KeywordDTO> getKeywordListInCommunity(Long communityId) {
 
         List<Keyword> allKeywordInCommunity = keywordRepository.findAllByCommunityId(communityId);
-        List<KeywordDTO> responseList = new ArrayList<>();
 
-        for (Keyword keyword : allKeywordInCommunity) {
+        return allKeywordInCommunity
+                .stream()
+                .map(keyword -> new KeywordDTO(
+                                        keyword.getId().toString(),
+                                        keyword.getKeyword(),
+                                        keyword.getKeywordUsers().size()))
+                .collect(Collectors.toList());
 
-            responseList.add(
-                    new KeywordDTO(
-                            String.valueOf(keyword.getId()),
-                            keyword.getKeyword(),
-                            keyword.getKeywordUsers().size()
-                    )
-            );
-        }
-
-        return responseList;
     }
 
     @Transactional

--- a/rest/src/main/java/com/waglewagle/rest/keyword/KeywordService.java
+++ b/rest/src/main/java/com/waglewagle/rest/keyword/KeywordService.java
@@ -98,4 +98,11 @@ public class KeywordService {
 
         keyword.addKeywordUser(new KeywordUser(joinKeywordDTO));
     }
+
+    @Transactional
+    public List<KeywordResponseDTO> getJoinedKeywords(Long userId, Long communityId) {
+
+        List<Keyword> keywords = keywordRepository.getJoinedKeywords(userId, communityId);
+        return KeywordResponseDTO.createKeywordResponses(keywords);
+    }
 }

--- a/rest/src/main/java/com/waglewagle/rest/keyword/association/DumbAssociateCalculator.java
+++ b/rest/src/main/java/com/waglewagle/rest/keyword/association/DumbAssociateCalculator.java
@@ -39,6 +39,10 @@ public class DumbAssociateCalculator implements AssociationCalculator {
             rank++;
         }
 
+        if (returnList.size() > 10) {
+            returnList = returnList.subList(0, 10);
+        }
+
         return returnList;
     }
 }


### PR DESCRIPTION
## 작업 결과물
```
GET

/api/v1/keyword/user/{community_id}

Request: 
- 인증 쿠키(user-id), 
- URL path parameter community_id

Response:
- 성공: status code 200
  - Array<{
      keywordId: string
      keywordName: string
    }>
- 실패: status code 400
```

## 작업 내용
- 커뮤니티 내 내가 참가한 키워드 API
- 키워드 추천 API 상위 10개 키워드만 반환하도록 변경
- 커뮤니티 내 키워드 API N+1 문제 해결