### PR TITLE
[feat] 키워드 내 전체 스레드 조회 API

### DIFF
--- a/rest/src/main/java/com/waglewagle/rest/keyword/KeywordService.java
+++ b/rest/src/main/java/com/waglewagle/rest/keyword/KeywordService.java
@@ -100,4 +100,9 @@ public class KeywordService {
         List<Keyword> keywords = keywordRepository.getJoinedKeywords(userId, communityId);
         return KeywordResponseDTO.createKeywordResponses(keywords);
     }
+
+    @Transactional
+    public boolean isKeywordExist(Long keywordId) {
+        return keywordRepository.findOne(keywordId) != null;
+    }
 }

--- a/rest/src/main/java/com/waglewagle/rest/thread/Thread.java
+++ b/rest/src/main/java/com/waglewagle/rest/thread/Thread.java
@@ -35,9 +35,10 @@ public class Thread {
     private Keyword keyword;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_thread_id")
     private Thread parentThread;
 
-    @OneToMany(mappedBy = "id")
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "parentThread")
     private List<Thread> children = new ArrayList<>();
 
     @CreationTimestamp

--- a/rest/src/main/java/com/waglewagle/rest/thread/ThreadController.java
+++ b/rest/src/main/java/com/waglewagle/rest/thread/ThreadController.java
@@ -1,5 +1,6 @@
 package com.waglewagle.rest.thread;
 
+import com.waglewagle.rest.keyword.KeywordService;
 import com.waglewagle.rest.thread.ThreadDTO.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -15,6 +16,7 @@ import java.util.List;
 public class ThreadController {
 
     private final ThreadService threadService;
+    private final KeywordService keywordService;
 
     /**
      * Thread 생성
@@ -58,4 +60,20 @@ public class ThreadController {
      *   updated_at: Date(?)
      * }
      */
+    @GetMapping("/keyword")
+    public ResponseEntity 함수_이름_뭐로_짓는_게_좋을까(@RequestParam("keyword-id") Long keywordId) {
+
+        if (!keywordService.isKeywordExist(keywordId)) {
+            // TODO : Error code
+            return new ResponseEntity(null, HttpStatus.NOT_FOUND);
+        }
+
+        List<ThreadResponseDTO> threadResponseDTOS = threadService.getThreadsInKeyword(keywordId);
+
+        if (threadResponseDTOS.isEmpty()) {
+            return new ResponseEntity(threadResponseDTOS, HttpStatus.NO_CONTENT);
+        }
+        return new ResponseEntity(threadResponseDTOS, HttpStatus.OK);
+
+    }
 }

--- a/rest/src/main/java/com/waglewagle/rest/thread/ThreadDTO.java
+++ b/rest/src/main/java/com/waglewagle/rest/thread/ThreadDTO.java
@@ -9,6 +9,7 @@ import lombok.Setter;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class ThreadDTO {
 
@@ -52,40 +53,40 @@ public class ThreadDTO {
 
         }
 
-
-        @Getter
-        public static class ThreadResponseDTO {
-
-            private String threadId;
-            private String content;
-            private LocalDateTime createdAt;
-            private LocalDateTime updatedAt;
-            private AuthorDTO author;
-            private List<ThreadResponseDTO> childThreads;
-
-//            protected ThreadResponseDTO () {}
-//
-//            /**
-//             * 이거 머지?
-//             */
-//            public static ThreadResponseDTO createThreadResponseDTO (Thread thread) {
-//                ThreadResponseDTO threadResponseDTO = new ThreadResponseDTO();
-//
-//                threadResponseDTO.threadId = thread.getId().toString();
-//                threadResponseDTO.content = thread.getContent();
-//                threadResponseDTO.createdAt = thread.getCreatedAt();
-//                threadResponseDTO.updatedAt = thread.getUpdatedAt();
-//                threadResponseDTO.childThreads = thread.getChildren().stream()
-//                        .map(ThreadResponseDTO::createThreadResponseDTO)
-//                        .collect(Collectors.toList());
-//
-//
-//
-//                return threadResponseDTO;
-//            }
-        }
-
     }
+
+
+    @Getter
+    public static class ThreadResponseDTO {
+
+        private String threadId;
+        private String content;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+        private AuthorDTO author;
+        private List<ThreadResponseDTO> childThreads;
+        private Integer childThreadCount;
+
+        public static ThreadResponseDTO of(Thread thread) {
+            ThreadResponseDTO threadResponseDTO = new ThreadResponseDTO();
+            threadResponseDTO.threadId = thread.getId().toString();
+            threadResponseDTO.content = thread.getContent();
+            threadResponseDTO.createdAt = thread.getCreatedAt();
+            threadResponseDTO.updatedAt = thread.getUpdatedAt();
+            threadResponseDTO.author = AuthorDTO.createAuthorDTO(thread.getAuthor());
+            if (thread.getParentThread() == null) {
+                threadResponseDTO.childThreads = thread
+                        .getChildren()
+                        .stream()
+                        .map(ThreadResponseDTO::of)
+                        .collect(Collectors.toList());
+                threadResponseDTO.childThreadCount = threadResponseDTO.childThreads.size();
+            }
+            return threadResponseDTO;
+        }
+    }
+
+
 
     @Getter
     @NoArgsConstructor

--- a/rest/src/main/java/com/waglewagle/rest/thread/ThreadRepository.java
+++ b/rest/src/main/java/com/waglewagle/rest/thread/ThreadRepository.java
@@ -22,6 +22,8 @@ public interface ThreadRepository extends JpaRepository<Thread, Long> {
     @Override
     void deleteById(Long id);
 
+    List<Thread> findThreadsByParentThreadIsNullAndKeywordId(Long keywordId);
+
     //    public Thread createThread(CreateThreadDTO createThreadDTO) {
 //
 //        Thread thread = new Thread(createThreadDTO);

--- a/rest/src/main/java/com/waglewagle/rest/thread/ThreadService.java
+++ b/rest/src/main/java/com/waglewagle/rest/thread/ThreadService.java
@@ -7,10 +7,12 @@ import com.waglewagle.rest.user.User;
 import com.waglewagle.rest.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import javax.transaction.Transactional;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -64,5 +66,14 @@ public class ThreadService {
 
         threadRepository.deleteAllByParentThreadId(threadId); //TODO: 아직 동작 확인 못함(테스트코드)
         threadRepository.deleteById(threadId);
+    }
+
+    @Transactional
+    public List<ThreadResponseDTO> getThreadsInKeyword(Long keywordId) {
+        List<Thread> threads = threadRepository.findThreadsByParentThreadIsNullAndKeywordId(keywordId);
+        return threads
+                .stream()
+                .map(ThreadResponseDTO::of)
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## 작업 결과물
```
GET

api/v1/thread/keyword?keyword-id=???

Request: 
- query parameter keyword-id: number

Response:
- 성공: status code 200 || 204 (빈 Array)
  - Array<{
      threadId: string
      content: string
      createdAt: string (date format)
      updatedAt: string (date format)
      author: {
        userId: string
        username: string
        profileImageUrl: string
      }
      childThreads: {
        threadId: string
        content: string
        createdAt: string (date format)
        updatedAt: string (date format)
        author: {
          userId: string
          username: string
          profileImageUrl: string
        }
        childThreads: null
        childThreadCount: null
      }
      childThreadCount: number
    }>
- 실패: status code 400
```

## 작업 내용

- 쓰레드 Entity가 children 멤버 변수에 자기 자신을 참조하던 버그 수정
- 키워드 내 쓰레드 API