### PR TITLE
[feat] 유저 최근 활동 시간 컬럼 및 api 추가

### DIFF
--- a/rest/src/main/java/com/waglewagle/rest/user/User.java
+++ b/rest/src/main/java/com/waglewagle/rest/user/User.java
@@ -33,6 +33,8 @@ public class User {
     @Enumerated(EnumType.STRING)
     private Role role;
 
+    private LocalDateTime lastActivity = LocalDateTime.now();
+
     @CreationTimestamp
     private LocalDateTime createdAt;
 
@@ -80,6 +82,10 @@ public class User {
         if (updateProfileDTO.getUsername() != null){
             username = updateProfileDTO.getUsername();
         }
+    }
+
+    public void updateLastActivity() {
+        lastActivity = LocalDateTime.now();
     }
 }
 

--- a/rest/src/main/java/com/waglewagle/rest/user/UserController.java
+++ b/rest/src/main/java/com/waglewagle/rest/user/UserController.java
@@ -2,6 +2,7 @@ package com.waglewagle.rest.user;
 
 import com.waglewagle.rest.user.dto.*;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
@@ -60,5 +61,12 @@ public class UserController {
         UserInfoResDTO userInfoDTO = userService.getUserInfo(userId, communityId);
 
         return ResponseEntity.ok(userInfoDTO);
+    }
+
+    @PutMapping("/last-activity")
+    public ResponseEntity updateLastActivity(@CookieValue("user_id") Long userId) {
+        userService.updateLastActivity(userId);
+
+        return new ResponseEntity(null, HttpStatus.OK);
     }
 }

--- a/rest/src/main/java/com/waglewagle/rest/user/UserController.java
+++ b/rest/src/main/java/com/waglewagle/rest/user/UserController.java
@@ -9,9 +9,10 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
-import java.util.*;
+import java.util.List;
+import java.util.Objects;
 
-import static com.waglewagle.rest.user.dto.UserInfoDTO.*;
+import static com.waglewagle.rest.user.dto.UserInfoDTO.UserInfoResDTO;
 
 @Controller
 @RequestMapping("/api/v1/user")
@@ -39,7 +40,7 @@ public class UserController {
     @ResponseBody
     public ResponseEntity<UpdateProfileResponseDTO> updateProfile(@RequestBody UpdateProfileDTO updateProfileDTO, @CookieValue(name = "user_id") Long userId) {
 
-        if(updateProfileDTO.isEmpty()) {
+        if (updateProfileDTO.isEmpty()) {
             return ResponseEntity.badRequest().build();
         }
 
@@ -68,5 +69,21 @@ public class UserController {
         userService.updateLastActivity(userId);
 
         return new ResponseEntity(null, HttpStatus.OK);
+    }
+
+    @GetMapping("keyword")
+    public ResponseEntity getUserInfoInKeyword(@RequestParam("keyword-id") Long keywordId) {
+
+        List<UserConnectionStatusDTO> userConnectionStatusDTOS = userService.getUserInfoInKeyword(keywordId);
+
+        return new ResponseEntity(userConnectionStatusDTOS, HttpStatus.OK);
+    }
+
+    @GetMapping("community")
+    public ResponseEntity getUserInfoInCommunity(@RequestParam("community-id") Long communityId) {
+
+        List<UserConnectionStatusDTO> userConnectionStatusDTOS = userService.getUserInfoInCommunity(communityId);
+
+        return new ResponseEntity(userConnectionStatusDTOS, HttpStatus.OK);
     }
 }

--- a/rest/src/main/java/com/waglewagle/rest/user/UserRepository.java
+++ b/rest/src/main/java/com/waglewagle/rest/user/UserRepository.java
@@ -11,6 +11,9 @@ import javax.persistence.TypedQuery;
 import java.util.List;
 import java.util.Optional;
 
+import static com.waglewagle.rest.keywordUser.QKeywordUser.keywordUser;
+import static com.waglewagle.rest.communityUser.QCommunityUser.communityUser;
+
 @Repository
 @RequiredArgsConstructor
 public class UserRepository {
@@ -74,4 +77,21 @@ public class UserRepository {
         return em.createQuery("SELECT u FROM User u WHERE u.username = :username").setParameter("username", username).getResultList();
     }
 
+    public List<User> findByKeywordUserKeywordId(Long keywordId) {
+        return jpqlQueryFactory
+                .select(keywordUser.user)
+                .from(keywordUser)
+                .where(keywordUser.keyword.id.eq(keywordId))
+                .orderBy(keywordUser.user.username.asc())
+                .fetch();
+    }
+
+    public List<User> findByCommunityUserCommunityId(Long communityId) {
+        return jpqlQueryFactory
+                .select(communityUser.user)
+                .from(communityUser)
+                .where(communityUser.community.id.eq(communityId))
+                .orderBy(communityUser.user.username.asc())
+                .fetch();
+    }
 }

--- a/rest/src/main/java/com/waglewagle/rest/user/UserRepository.java
+++ b/rest/src/main/java/com/waglewagle/rest/user/UserRepository.java
@@ -1,5 +1,6 @@
 package com.waglewagle.rest.user;
 
+import com.querydsl.jpa.JPQLQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +16,7 @@ import java.util.Optional;
 public class UserRepository {
 
     private final EntityManager em;
+    private final JPQLQueryFactory jpqlQueryFactory;
 
     @Transactional
     public User save(User user) {
@@ -71,4 +73,5 @@ public class UserRepository {
     public List<User> findByUsername(String username) {
         return em.createQuery("SELECT u FROM User u WHERE u.username = :username").setParameter("username", username).getResultList();
     }
+
 }

--- a/rest/src/main/java/com/waglewagle/rest/user/UserService.java
+++ b/rest/src/main/java/com/waglewagle/rest/user/UserService.java
@@ -4,6 +4,7 @@ import com.waglewagle.rest.communityUser.CommunityUser;
 import com.waglewagle.rest.communityUser.CommunityUserRepository;
 import com.waglewagle.rest.keywordUser.KeywordUser;
 import com.waglewagle.rest.user.dto.UpdateProfileDTO;
+import com.waglewagle.rest.user.dto.UserConnectionStatusDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -12,6 +13,7 @@ import javax.transaction.Transactional;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.waglewagle.rest.user.dto.UserInfoDTO.*;
 
@@ -83,5 +85,21 @@ public class UserService {
 
         user.updateLastActivity();
 
+    }
+
+    public List<UserConnectionStatusDTO> getUserInfoInKeyword(Long keywordId) {
+        return userRepository
+                .findByKeywordUserKeywordId(keywordId)
+                .stream()
+                .map(UserConnectionStatusDTO::of)
+                .collect(Collectors.toList());
+    }
+
+    public List<UserConnectionStatusDTO> getUserInfoInCommunity(Long communityId) {
+        return userRepository
+                .findByCommunityUserCommunityId(communityId)
+                .stream()
+                .map(UserConnectionStatusDTO::of)
+                .collect(Collectors.toList());
     }
 }

--- a/rest/src/main/java/com/waglewagle/rest/user/UserService.java
+++ b/rest/src/main/java/com/waglewagle/rest/user/UserService.java
@@ -4,7 +4,6 @@ import com.waglewagle.rest.communityUser.CommunityUser;
 import com.waglewagle.rest.communityUser.CommunityUserRepository;
 import com.waglewagle.rest.keywordUser.KeywordUser;
 import com.waglewagle.rest.user.dto.UpdateProfileDTO;
-import com.waglewagle.rest.user.dto.UserInfoDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -76,5 +75,13 @@ public class UserService {
     public List<KeywordUser> getUserKeywords(Long userId) {
         User user = userRepository.findById(userId);
         return null;
+    }
+
+    @Transactional
+    public void updateLastActivity(Long userId) {
+        User user = userRepository.findById(userId);
+
+        user.updateLastActivity();
+
     }
 }

--- a/rest/src/main/java/com/waglewagle/rest/user/dto/UserConnectionStatusDTO.java
+++ b/rest/src/main/java/com/waglewagle/rest/user/dto/UserConnectionStatusDTO.java
@@ -1,0 +1,24 @@
+package com.waglewagle.rest.user.dto;
+
+import com.waglewagle.rest.user.User;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class UserConnectionStatusDTO {
+
+    private String userId;
+    private String username;
+    private String profileImageUrl;
+    private LocalDateTime lastActivity;
+
+    public static UserConnectionStatusDTO of(User user) {
+        UserConnectionStatusDTO userConnectionStatusDTO = new UserConnectionStatusDTO();
+        userConnectionStatusDTO.userId = user.getId().toString();
+        userConnectionStatusDTO.username = user.getUsername();
+        userConnectionStatusDTO.profileImageUrl = user.getProfileImageUrl();
+        userConnectionStatusDTO.lastActivity = user.getLastActivity();
+        return userConnectionStatusDTO;
+    }
+}


### PR DESCRIPTION
## 작업 결과물
```
PUT
api/v1/user/last-activity

Response Body
null
```
```
GET
api/v1/user/keyword

Query params
keyword-id: number

Response Body
Array<{
  userId: string
  username: string
  profileImageUrl: string
  lastActivity: string (YYYY-MM-DD\T\HH:MM:SS) ( ex) "2022-12-04T14:20:48" )
}>
```
```
GET
api/v1/user/community

Query params
community-id: number

Response Body
Array<{
  userId: string
  username: string
  profileImageUrl: string
  lastActivity: string (YYYY-MM-DD\T\HH:MM:SS) ( ex) "2022-12-04T14:20:48" )
}>
```

## 작업 배경 

- 같은 커뮤니티 혹은 키워드 그룹 내에서 다른 사용자의 접속 상태를 확인할 수 있는 방법이 없었음.

## 작업 내용

- User entity에 last-activity 컬럼 추가
  - default는 CURRENT_TIMESTAMP
- 해당 컬럼을 변경할 수 있는 API 추가
- 해당 컬럼의 정보를 포함하여 특정 그룹 내의 유저들의 정보를 얻을 수 있는 API 추가
