### PR TITLE
[feat] oauth user entity에 last_activity 필드 추가

### DIFF
--- a/oauth/package.json
+++ b/oauth/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "tsc node dist/app.js"
+    "start": "tsc && node dist/main.js"
   },
   "keywords": [],
   "author": "",

--- a/oauth/src/domain/oauth/oauth.service.ts
+++ b/oauth/src/domain/oauth/oauth.service.ts
@@ -18,8 +18,8 @@ const handleAuthenticationCode: requestHandler = async (req, res) => {
   }
 
   const access_token = await getAccessToken(code);
-  const { id, login, avatar_url } = await getUserProfile(access_token);
-  const user = await userRepository.handleUserProfile({ id: id.toString(), login, avatar_url });
+  const { id, login, avatar_url, email } = await getUserProfile(access_token);
+  const user = await userRepository.handleUserProfile({ id: id.toString(), login, avatar_url, email });
   res.cookie('user_id', user.id, { httpOnly: true });
   res.redirect('/');
   return;
@@ -55,8 +55,8 @@ const getUserProfile = async (accessToken: string) => {
       'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
     },
   });
-  const { id, login, avatar_url } = data as { id: number; login: string; avatar_url: string };
-  return { id, login, avatar_url };
+  const { id, login, avatar_url, email } = data as { id: number; login: string; avatar_url: string; email?: string };
+  return { id, login, avatar_url, email };
 };
 
 export { redirectToGithubLogin, handleAuthenticationCode };

--- a/oauth/src/domain/oauth/user.entity.ts
+++ b/oauth/src/domain/oauth/user.entity.ts
@@ -7,6 +7,7 @@ import {
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
+import { RoleEnum } from '../../enum/roll.enum';
 
 @Entity('user')
 export class User extends BaseEntity {
@@ -29,6 +30,19 @@ export class User extends BaseEntity {
     length: 255,
   })
   username: string | null;
+
+  @Column('varchar', { name: 'role', nullable: false, default: () => RoleEnum.USER })
+  role: string;
+
+  @Column('varchar', { name: 'email' })
+  email: string;
+
+  @Column('datetime', {
+    name: 'last_activity',
+    nullable: false,
+    default: () => 'CURRENT_TIMESTAMP',
+  })
+  lastActivity: Date;
 
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;

--- a/oauth/src/domain/oauth/user.entity.ts
+++ b/oauth/src/domain/oauth/user.entity.ts
@@ -25,7 +25,6 @@ export class User extends BaseEntity {
 
   @Column('varchar', {
     name: 'username',
-    nullable: true,
     unique: true,
     length: 255,
   })

--- a/oauth/src/domain/oauth/user.repository.ts
+++ b/oauth/src/domain/oauth/user.repository.ts
@@ -5,12 +5,14 @@ const handleUserProfile = ({
   id,
   login,
   avatar_url,
+  email,
 }: {
   id: string;
   login: string;
   avatar_url: string;
+  email?: string;
 }): Promise<User> => {
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve) => {
     dataSource.transaction(async (em) => {
       const existingUser = await em.getRepository(User).findOne({
         where: {
@@ -23,8 +25,10 @@ const handleUserProfile = ({
       const user = new User();
       user.oauthMethod = 'GITHUB';
       user.oauthKey = id;
-      user.username = (await em.getRepository(User).findOneBy({ username: login })) ? crypto.randomUUID() : login;
+      user.username = (await em.getRepository(User).countBy({ username: login })) ? crypto.randomUUID() : login;
       user.profileImageUrl = avatar_url;
+      if (email) user.email = email;
+
       return resolve(em.save(user));
     });
   });

--- a/oauth/src/domain/oauth/user.repository.ts
+++ b/oauth/src/domain/oauth/user.repository.ts
@@ -20,6 +20,7 @@ const handleUserProfile = ({
           oauthMethod: 'GITHUB',
         },
       });
+
       if (existingUser) return resolve(existingUser);
 
       const user = new User();
@@ -29,7 +30,7 @@ const handleUserProfile = ({
       user.profileImageUrl = avatar_url;
       if (email) user.email = email;
 
-      return resolve(em.save(user));
+      return resolve(await em.save(user));
     });
   });
 };

--- a/oauth/src/enum/roll.enum.ts
+++ b/oauth/src/enum/roll.enum.ts
@@ -1,0 +1,4 @@
+export enum RoleEnum {
+  USER,
+  ADMIN,
+}

--- a/oauth/src/enum/roll.enum.ts
+++ b/oauth/src/enum/roll.enum.ts
@@ -1,4 +1,4 @@
 export enum RoleEnum {
-  USER,
-  ADMIN,
+  USER = 'USER',
+  ADMIN = 'ADMIN',
 }

--- a/oauth/src/util/utils.ts
+++ b/oauth/src/util/utils.ts
@@ -2,7 +2,7 @@ function deepFreeze<T extends object>(data: T): T {
   Object.freeze(data);
 
   Object.values(data).forEach((value) => {
-    if (value === 'object') {
+    if (typeof value === 'object') {
       Object.freeze(value);
       deepFreeze(value);
     }
@@ -12,4 +12,3 @@ function deepFreeze<T extends object>(data: T): T {
 }
 
 export { deepFreeze };
-const a: Iterable<number> = [1, 2, 3];


### PR DESCRIPTION
## 작업 결과물

- User entity의 일부 컬럼 추가

## 작업 배경 

- oauth 서버에서 User 엔티티의 일부 column이 반영되어 있지 않던 문제가 있었음.

## 작업 내용

- Oauth server의 User entity에 다음 컬럼 추가
  - last_activity
    - default CURRENT_TIMESTAMP
  - role
    - default USER
  - email
