### PR TITLE
[fix] 커뮤니티내 전체 키워드 리스트 조회 API (GET /keyword/community-id) 객체 중복 조회 해결

### DIFF
--- a/rest/src/main/java/com/waglewagle/rest/keyword/KeywordRepository.java
+++ b/rest/src/main/java/com/waglewagle/rest/keyword/KeywordRepository.java
@@ -30,11 +30,12 @@ public class KeywordRepository {
     public List<Keyword> findAllByCommunityId(Long communityId) {
         return jpaQueryFactory
                 .selectFrom(keyword1)
+                .distinct()
                 .innerJoin(keyword1.community, community)
                 .innerJoin(keyword1.keywordUsers, keywordUser)
-                .where(community.id.eq(communityId))
                 .fetchJoin()
-                .fetch(); //TODO: fetchJoin?
+                .where(community.id.eq(communityId))
+                .fetch();
     }
 
     public List<Keyword> findAssociatedKeywords(Keyword keyword) {


### PR DESCRIPTION
# 버그이유
JPA N+1 문제 해결 과정에서, 카테시안 곱 현상이 발생함

# 해결
쿼리문에 distinct 키워드를 추가하여 해결