### PR TITLE
[Feat] 전역 ExceptionHandler 구현(+예시 하나)

### DIFF
--- a/rest/src/main/java/com/waglewagle/rest/common/error/GlobalExceptionHandler.java
+++ b/rest/src/main/java/com/waglewagle/rest/common/error/GlobalExceptionHandler.java
@@ -1,0 +1,31 @@
+package com.waglewagle.rest.common.error;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.Arrays;
+import java.util.NoSuchElementException;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @Getter
+    @RequiredArgsConstructor
+    private static final class ExceptionResponse {
+
+        private final String message;
+    }
+
+    @ExceptionHandler(NoSuchElementException.class)
+    protected final ResponseEntity<ExceptionResponse>
+    handleNoSuchElementException(final NoSuchElementException e) {
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(new ExceptionResponse(e.getMessage()));
+    }
+}

--- a/rest/src/main/java/com/waglewagle/rest/keyword/exception/ExceptionMessage.java
+++ b/rest/src/main/java/com/waglewagle/rest/keyword/exception/ExceptionMessage.java
@@ -1,0 +1,13 @@
+package com.waglewagle.rest.keyword.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ExceptionMessage {
+
+    NO_SUCH_KEYWORD("키워드를 찾을 수 없습니다.");
+
+    private final String message;
+}

--- a/rest/src/main/java/com/waglewagle/rest/keyword/exception/NoSuchKeywordException.java
+++ b/rest/src/main/java/com/waglewagle/rest/keyword/exception/NoSuchKeywordException.java
@@ -1,0 +1,9 @@
+package com.waglewagle.rest.keyword.exception;
+
+import java.util.NoSuchElementException;
+public class NoSuchKeywordException extends NoSuchElementException {
+
+    public NoSuchKeywordException() {
+        super(ExceptionMessage.NO_SUCH_KEYWORD.getMessage());
+    }
+}


### PR DESCRIPTION
# 📄 작업 결과물
- 컨트롤러의 에러를 전역적으로 처리해주는 `GlobalExceptionHandler`를 구현.
- 도메인 아래의 에러들을 어떻게 처리할지에 대해 룰을 정함.

# 🏗️ 작업 배경
1. 서비스 레이어의 메서드 들에 대한 단위 테스트를 짜려고 하는데, 컨트롤러에 관심사가 너무 몰려있어(서비스 레이어 메서드 여럿을 컨트롤러에서 호출 중), 단위 테스트로 구성하기에 부적합하였음.
2. 컨트롤러 메서드의 관심사를 서비스 레이어로 내려, 서비스 레이어 메소드들 각각에 대해 단위 테스트를 구성하고자 함.
3. 서비스 메서드가 가지고 있는 분기가, 값을 반환하는 성공 분기, 예외를 throw하는 실패 분기로 나뉘고, 실패 분기는 다시 여러 유형의 예외로 나뉜다.
    \>>  **난립하는 커스텀 에러와 에러 메세지, try-catch로 뚱뚱해지는 컨트롤러 메서드

# 💻 작업 내용
- Spring의 전역 예외 관리 방법인, `@RestControlllerAdvice`와 `@ExceptionHandler` 사용하였음.

# ➡️ 이후 작업 내용
- 바뀐 구조를 기반으로 API 코드 리팩토링, 이후 단위 테스트 작성