### PR TITLE
[refactor] validation 로직을 controller에서 service로 이동, Optional 사용 증가

### DIFF
--- a/rest/src/main/java/com/waglewagle/rest/community/repository/custom/CommunityUserCustomRepository.java
+++ b/rest/src/main/java/com/waglewagle/rest/community/repository/custom/CommunityUserCustomRepository.java
@@ -2,7 +2,11 @@ package com.waglewagle.rest.community.repository.custom;
 
 import com.waglewagle.rest.community.entity.CommunityUser;
 
+import java.util.Optional;
+
 public interface CommunityUserCustomRepository {
 
-    public CommunityUser findByUserIdAndCommunityId(Long userId, Long communityId);
+    CommunityUser findByUserIdAndCommunityId(Long userId, Long communityId);
+
+    Optional<CommunityUser> findOptionalByUserIdAndCommunityId(Long userId, Long communityId);
 }

--- a/rest/src/main/java/com/waglewagle/rest/community/repository/custom/CommunityUserCustomRepositoryImpl.java
+++ b/rest/src/main/java/com/waglewagle/rest/community/repository/custom/CommunityUserCustomRepositoryImpl.java
@@ -6,6 +6,8 @@ import com.waglewagle.rest.community.entity.QCommunityUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 
 @Repository
 @RequiredArgsConstructor
@@ -24,5 +26,19 @@ public class CommunityUserCustomRepositoryImpl implements CommunityUserCustomRep
                 .where(QCommunityUser.communityUser.community.id.eq(communityId))
                 .where(QCommunityUser.communityUser.user.id.eq(userId))
                 .fetchOne();
+    }
+
+    @Override
+    public Optional<CommunityUser>
+    findOptionalByUserIdAndCommunityId(final Long userId,
+                                       final Long communityId) {
+        return Optional.ofNullable(
+                jpqlQueryFactory
+                        .select(QCommunityUser.communityUser)
+                        .from(QCommunityUser.communityUser)
+                        .where(QCommunityUser.communityUser.user.id.eq(userId))
+                        .where(QCommunityUser.communityUser.community.id.eq(communityId))
+                        .fetchOne()
+        );
     }
 }

--- a/rest/src/main/java/com/waglewagle/rest/community/service/CommunityUserService.java
+++ b/rest/src/main/java/com/waglewagle/rest/community/service/CommunityUserService.java
@@ -47,10 +47,9 @@ public class CommunityUserService {
 
     @Transactional
     public void
-    updateCommunityUserProfile(
-            final CommunityUserRequest.UpdateProfileDTO updateProfileDTO,
-            final Long communityId,
-            final Long userId) {
+    updateCommunityUserProfile(final CommunityUserRequest.UpdateProfileDTO updateProfileDTO,
+                               final Long communityId,
+                               final Long userId) {
 
         communityUserRepository
                 .findByUserIdAndCommunityId(userId, communityId)

--- a/rest/src/main/java/com/waglewagle/rest/keyword/repository/KeywordRepository.java
+++ b/rest/src/main/java/com/waglewagle/rest/keyword/repository/KeywordRepository.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -25,6 +26,16 @@ public class KeywordRepository {
     public Keyword
     findOne(final Long keywordId) {
         return em.find(Keyword.class, keywordId);
+    }
+
+
+    public Optional<Keyword>
+    findById(final Long keywordId) {
+        return Optional
+                .ofNullable(
+                        em
+                                .find(Keyword.class, keywordId)
+                );
     }
 
     public List<Keyword>

--- a/rest/src/main/java/com/waglewagle/rest/keyword/service/KeywordUserService.java
+++ b/rest/src/main/java/com/waglewagle/rest/keyword/service/KeywordUserService.java
@@ -32,10 +32,10 @@ public class KeywordUserService {
 
         User user = userRepository
                 .findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+                .orElseThrow(IllegalArgumentException::new);
         Community community = communityRepository
                 .findById(disjoinDTO.getCommunityId())
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 커뮤니티입니다."));
+                .orElseThrow(IllegalArgumentException::new);
 
         keywordUserRepository.deleteByKeywordAndCommunityAndUser(keyword, community, user);
     }

--- a/rest/src/main/java/com/waglewagle/rest/thread/controller/ThreadController.java
+++ b/rest/src/main/java/com/waglewagle/rest/thread/controller/ThreadController.java
@@ -1,5 +1,6 @@
 package com.waglewagle.rest.thread.controller;
 
+import com.waglewagle.rest.common.PreResponseDTO;
 import com.waglewagle.rest.keyword.service.KeywordService;
 import com.waglewagle.rest.thread.data_object.dto.request.ThreadRequest;
 import com.waglewagle.rest.thread.data_object.dto.response.ThreadResponse;
@@ -26,16 +27,22 @@ public class ThreadController {
      */
     @PostMapping("")
     @ResponseBody
-    public ResponseEntity<String> createThread(@CookieValue("user_id") Long userId,
-                                               @RequestBody ThreadRequest.CreateThreadInputDTO createThreadInputDTO) {
-        if (!createThreadInputDTO.isValid())
+    public ResponseEntity<ThreadResponse.ThreadDTO>
+    createThread(@CookieValue("user_id") final Long userId,
+                 @RequestBody final ThreadRequest.CreateDTO createDTO) {
+        if (!createDTO.isValid())
             return new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);
-        
+
         try {
-            threadService.creatThread(userId, createThreadInputDTO);
-            return new ResponseEntity<>(null, HttpStatus.CREATED);
+            PreResponseDTO preResponseDTO = threadService.creatThread(userId, createDTO);
+            return new ResponseEntity<>(
+                    preResponseDTO.getData(),
+                    preResponseDTO.getHttpStatus());
+
         } catch (IllegalArgumentException e) {
-            return new ResponseEntity<>(e.getMessage(), HttpStatus.NOT_FOUND);
+            return new ResponseEntity<>(
+                    null,
+                    HttpStatus.NOT_FOUND);
         }
     }
 
@@ -45,11 +52,11 @@ public class ThreadController {
      */
     @DeleteMapping("")
     @ResponseBody
-    public ResponseEntity<Boolean> deleteThread(@CookieValue("user_id") Long userId,
-                                                @RequestBody ThreadRequest.DeleteDTO deleteDTO) {
+    public ResponseEntity<Boolean>
+    deleteThread(@CookieValue("user_id") final Long userId,
+                 @RequestBody final ThreadRequest.DeleteDTO deleteDTO) {
 
         threadService.deleteThread(userId, deleteDTO.getThreadId());
-
         return new ResponseEntity<>(true, HttpStatus.ACCEPTED);
     }
 
@@ -70,19 +77,20 @@ public class ThreadController {
      * }
      */
     @GetMapping("/keyword")
-    public ResponseEntity getThreadsInKeyword(@RequestParam("keyword-id") Long keywordId) {
+    public ResponseEntity<List<ThreadResponse.ThreadDTO>>
+    getThreadsInKeyword(@RequestParam("keyword-id") final Long keywordId) {
 
         if (!keywordService.isKeywordExist(keywordId)) {
             // TODO : Error code
             return new ResponseEntity(null, HttpStatus.NOT_FOUND);
         }
 
-        List<ThreadResponse.ThreadDTO> threadResponseDTOS = threadService.getThreadsInKeyword(keywordId);
+        PreResponseDTO<List<ThreadResponse.ThreadDTO>>
+                preResponseDTO = threadService.getThreadsInKeyword(keywordId);
 
-        if (threadResponseDTOS.isEmpty()) {
-            return new ResponseEntity(null, HttpStatus.NO_CONTENT);
-        }
 
-        return new ResponseEntity(threadResponseDTOS, HttpStatus.OK);
+        return new ResponseEntity(
+                preResponseDTO.getData(),
+                preResponseDTO.getHttpStatus());
     }
 }

--- a/rest/src/main/java/com/waglewagle/rest/thread/controller/ThreadController.java
+++ b/rest/src/main/java/com/waglewagle/rest/thread/controller/ThreadController.java
@@ -33,17 +33,12 @@ public class ThreadController {
         if (!createDTO.isValid())
             return new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);
 
-        try {
-            PreResponseDTO preResponseDTO = threadService.creatThread(userId, createDTO);
-            return new ResponseEntity<>(
-                    preResponseDTO.getData(),
-                    preResponseDTO.getHttpStatus());
+        PreResponseDTO<ThreadResponse.ThreadDTO>
+                preResponseDTO = threadService.creatThread(userId, createDTO);
+        return new ResponseEntity<>(
+                preResponseDTO.getData(),
+                preResponseDTO.getHttpStatus());
 
-        } catch (IllegalArgumentException e) {
-            return new ResponseEntity<>(
-                    null,
-                    HttpStatus.NOT_FOUND);
-        }
     }
 
     /**

--- a/rest/src/main/java/com/waglewagle/rest/thread/data_object/dto/request/ThreadRequest.java
+++ b/rest/src/main/java/com/waglewagle/rest/thread/data_object/dto/request/ThreadRequest.java
@@ -8,28 +8,28 @@ public class ThreadRequest {
 
     @Getter
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
-    public static class CreateThreadInputDTO {
+    public static class CreateDTO {
 
         private Long keywordId;
         private Long parentThreadId;
         private String content;
 
-        public static CreateThreadInputDTO from(final Long keywordId,
-                                                final String content) {
-            CreateThreadInputDTO createThreadInputDTO = new CreateThreadInputDTO();
-            createThreadInputDTO.keywordId = keywordId;
-            createThreadInputDTO.content = content;
-            return createThreadInputDTO;
+        public static CreateDTO from(final Long keywordId,
+                                     final String content) {
+            CreateDTO createDTO = new CreateDTO();
+            createDTO.keywordId = keywordId;
+            createDTO.content = content;
+            return createDTO;
         }
 
-        public static CreateThreadInputDTO from(final Long keywordId,
-                                                final Long parentThreadId,
-                                                final String content) {
-            CreateThreadInputDTO createThreadInputDTO = new CreateThreadInputDTO();
-            createThreadInputDTO.keywordId = keywordId;
-            createThreadInputDTO.parentThreadId = parentThreadId;
-            createThreadInputDTO.content = content;
-            return createThreadInputDTO;
+        public static CreateDTO from(final Long keywordId,
+                                     final Long parentThreadId,
+                                     final String content) {
+            CreateDTO createDTO = new CreateDTO();
+            createDTO.keywordId = keywordId;
+            createDTO.parentThreadId = parentThreadId;
+            createDTO.content = content;
+            return createDTO;
         }
 
         public boolean isValid() {

--- a/rest/src/main/java/com/waglewagle/rest/thread/repository/custom/ThreadCustomRepositoryImpl.java
+++ b/rest/src/main/java/com/waglewagle/rest/thread/repository/custom/ThreadCustomRepositoryImpl.java
@@ -14,7 +14,8 @@ public class ThreadCustomRepositoryImpl implements ThreadCustomRepository {
 
     private final JPQLQueryFactory jpqlQueryFactory;
 
-    public List<Thread> findParentThreadsInKeyword(Long keywordId) {
+    public List<Thread>
+    findParentThreadsInKeyword(Long keywordId) {
         return jpqlQueryFactory
                 .selectFrom(QThread.thread)
                 .leftJoin(QThread.thread.author)
@@ -26,7 +27,8 @@ public class ThreadCustomRepositoryImpl implements ThreadCustomRepository {
 
     }
 
-    public List<Thread> findChildThreads(List<Long> threadIds) {
+    public List<Thread>
+    findChildThreads(List<Long> threadIds) {
         return jpqlQueryFactory
                 .selectFrom(QThread.thread)
                 .leftJoin(QThread.thread.author)

--- a/rest/src/main/java/com/waglewagle/rest/user/controller/UserController.java
+++ b/rest/src/main/java/com/waglewagle/rest/user/controller/UserController.java
@@ -24,8 +24,9 @@ public class UserController {
 
     @PostMapping("/login")
     @ResponseBody
-    public ResponseEntity<UserResponse.LoginDTO> authenticateWithUsername(@RequestBody UserRequest.UsernameLoginDTO usernameLoginDTO,
-                                                                          HttpServletResponse response) {
+    public ResponseEntity<UserResponse.LoginDTO>
+    authenticateWithUsername(@RequestBody final UserRequest.UsernameLoginDTO usernameLoginDTO,
+                             HttpServletResponse response) {
 
         String username = usernameLoginDTO.getUsername();
         Long userId = userService.authenticateWithUsername(username);
@@ -39,30 +40,39 @@ public class UserController {
 
     @PutMapping("/profile")
     @ResponseBody
-    public ResponseEntity<UserResponse.UpdateProfileDTO> updateProfile(@RequestBody UserRequest.UpdateProfileDTO updateProfileDTO,
-                                                                       @CookieValue(name = "user_id") Long userId) {
+    public ResponseEntity<UserResponse.UpdateProfileDTO>
+    updateProfile(@RequestBody final UserRequest.UpdateProfileDTO updateProfileDTO,
+                  @CookieValue(name = "user_id") final Long userId) {
 
         if (updateProfileDTO.isEmpty()) {
             return new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);
         }
 
-        PreResponseDTO<UserResponse.UpdateProfileDTO> preResponseDTO = userService.updateUserProfile(userId, updateProfileDTO);
+        PreResponseDTO<UserResponse.UpdateProfileDTO>
+                preResponseDTO = userService.updateUserProfile(userId, updateProfileDTO);
 
-        return new ResponseEntity<>(preResponseDTO.getData(), preResponseDTO.getHttpStatus());
+        return new ResponseEntity<>(
+                preResponseDTO.getData(),
+                preResponseDTO.getHttpStatus());
     }
 
     @GetMapping("/me")
     @ResponseBody
-    public ResponseEntity<UserResponse.UserInfoDTO> getUserInfo(@CookieValue(name = "user_id") Long userId,
-                                                                @RequestParam(name = "community-id", required = false) Long communityId) {
+    public ResponseEntity<UserResponse.UserInfoDTO>
+    getUserInfo(@CookieValue(name = "user_id") final Long userId,
+                @RequestParam(name = "community-id", required = false) final Long communityId) {
 
-        PreResponseDTO<UserResponse.UserInfoDTO> preResponseDTO = userService.getUserInfo(userId, communityId);
+        PreResponseDTO<UserResponse.UserInfoDTO>
+                preResponseDTO = userService.getUserInfo(userId, communityId);
 
-        return new ResponseEntity(preResponseDTO.getData(), preResponseDTO.getHttpStatus());
+        return new ResponseEntity(
+                preResponseDTO.getData(),
+                preResponseDTO.getHttpStatus());
     }
 
     @PutMapping("/last-activity")
-    public ResponseEntity<String> updateLastActivity(@CookieValue("user_id") Long userId) {
+    public ResponseEntity<String>
+    updateLastActivity(@CookieValue("user_id") final Long userId) {
 
         try {
             userService.updateLastActivity(userId);
@@ -70,22 +80,32 @@ public class UserController {
             return new ResponseEntity<>(e.getMessage(), HttpStatus.NOT_FOUND);
         }
 
-        return new ResponseEntity<>(null, HttpStatus.OK);
+        return new ResponseEntity<>(
+                null,
+                HttpStatus.OK);
     }
 
     @GetMapping("keyword")
-    public ResponseEntity getUserInfoInKeyword(@RequestParam("keyword-id") Long keywordId) {
+    public ResponseEntity<List<UserResponse.LastActivityDTO>>
+    getUserInfoInKeyword(@RequestParam("keyword-id") final Long keywordId) {
 
-        List<UserResponse.LastActivityDTO> lastActivityDTOS = userService.getUserInfoInKeyword(keywordId);
+        List<UserResponse.LastActivityDTO>
+                lastActivityDTOS = userService.getUserInfoInKeyword(keywordId);
 
-        return new ResponseEntity(lastActivityDTOS, HttpStatus.OK);
+        return new ResponseEntity<>(
+                lastActivityDTOS,
+                HttpStatus.OK);
     }
 
     @GetMapping("community")
-    public ResponseEntity getUserInfoInCommunity(@RequestParam("community-id") Long communityId) {
+    public ResponseEntity<List<UserResponse.LastActivityDTO>>
+    getUserInfoInCommunity(@RequestParam("community-id") final Long communityId) {
 
-        List<UserResponse.LastActivityDTO> lastActivityDTOS = userService.getUserInfoInCommunity(communityId);
+        List<UserResponse.LastActivityDTO>
+                lastActivityDTOS = userService.getUserInfoInCommunity(communityId);
 
-        return new ResponseEntity(lastActivityDTOS, HttpStatus.OK);
+        return new ResponseEntity(
+                lastActivityDTOS,
+                HttpStatus.OK);
     }
 }

--- a/rest/src/main/java/com/waglewagle/rest/user/entity/User.java
+++ b/rest/src/main/java/com/waglewagle/rest/user/entity/User.java
@@ -57,13 +57,6 @@ public class User {
         this.role = role;
     }
 
-    public User update(String username, String profileImageUrl) {
-        this.username = username;
-        this.profileImageUrl = profileImageUrl;
-
-        return this;
-    }
-
     public String getRoleKey() {
         return this.role.getKey();
     }

--- a/rest/src/main/java/com/waglewagle/rest/user/repository/custom/UserCustomRepositoryImpl.java
+++ b/rest/src/main/java/com/waglewagle/rest/user/repository/custom/UserCustomRepositoryImpl.java
@@ -24,7 +24,8 @@ public class UserCustomRepositoryImpl implements UserCustomRepository {
 
 
     @Transactional
-    public Long findOrSaveUsername(String username) {
+    public Long
+    findOrSaveUsername(final String username) {
         User user = jpqlQueryFactory
                 .select(QUser.user)
                 .from(QUser.user)
@@ -36,14 +37,15 @@ public class UserCustomRepositoryImpl implements UserCustomRepository {
             user.setUsername(username);
             user.setOauthKey(username);
             user.setOauthMethod(OauthMethod.USERNAME);
-            
+
             entityManager.persist(user);
         }
 
         return user.getId();
     }
 
-    public List<User> findByKeywordUserKeywordId(Long keywordId) {
+    public List<User>
+    findByKeywordUserKeywordId(final Long keywordId) {
         return jpqlQueryFactory
                 .select(keywordUser.user)
                 .from(keywordUser)
@@ -52,7 +54,8 @@ public class UserCustomRepositoryImpl implements UserCustomRepository {
                 .fetch();
     }
 
-    public List<User> findByCommunityUserCommunityId(Long communityId) {
+    public List<User>
+    findByCommunityUserCommunityId(final Long communityId) {
         return jpqlQueryFactory
                 .select(communityUser.user)
                 .from(communityUser)

--- a/rest/src/main/java/com/waglewagle/rest/user/service/UserService.java
+++ b/rest/src/main/java/com/waglewagle/rest/user/service/UserService.java
@@ -26,12 +26,14 @@ public class UserService {
     private final CommunityUserRepository communityUserRepository;
 
     @Transactional
-    public Long authenticateWithUsername(final String username) {
+    public Long
+    authenticateWithUsername(final String username) {
         Long userId = userRepository.findOrSaveUsername(username);
         return userId;
     }
 
-    public Cookie createUserIdCookie(final Long userId) {
+    public Cookie
+    createUserIdCookie(final Long userId) {
         Cookie userIdCookie = new Cookie("user_id", Long.toString(userId));
         userIdCookie.setMaxAge(3600 * 1000);
         userIdCookie.setPath("/");
@@ -41,8 +43,9 @@ public class UserService {
     }
 
     @Transactional
-    public PreResponseDTO<UserResponse.UpdateProfileDTO> updateUserProfile(final Long userId,
-                                                                           final UserRequest.UpdateProfileDTO updateProfileDTO) throws IllegalArgumentException {
+    public PreResponseDTO<UserResponse.UpdateProfileDTO>
+    updateUserProfile(final Long userId,
+                      final UserRequest.UpdateProfileDTO updateProfileDTO) throws IllegalArgumentException {
 
         User user = userRepository
                 .findById(userId)
@@ -55,7 +58,7 @@ public class UserService {
                     .findByUsername(username)
                     .filter(user1 -> !Objects.equals(user.getId(), userId))
                     .isPresent();
-            
+
             if (isUsedUsername) {
                 return new PreResponseDTO("이미 사용중인 이름입니다.", HttpStatus.BAD_REQUEST);
             }
@@ -67,7 +70,9 @@ public class UserService {
     }
 
     @Transactional
-    public PreResponseDTO<UserResponse.UserInfoDTO> getUserInfo(final Long userId, final Long communityId) throws IllegalArgumentException {
+    public PreResponseDTO<UserResponse.UserInfoDTO>
+    getUserInfo(final Long userId,
+                final Long communityId) throws IllegalArgumentException {
         try {
             User user = userRepository
                     .findById(userId)
@@ -92,7 +97,8 @@ public class UserService {
     }
 
     @Transactional
-    public void updateLastActivity(Long userId) throws IllegalArgumentException {
+    public void
+    updateLastActivity(final Long userId) throws IllegalArgumentException {
         userRepository
                 .findById(userId)
                 .orElseThrow(
@@ -101,7 +107,8 @@ public class UserService {
                 .updateLastActivity();
     }
 
-    public List<UserResponse.LastActivityDTO> getUserInfoInKeyword(Long keywordId) {
+    public List<UserResponse.LastActivityDTO>
+    getUserInfoInKeyword(final Long keywordId) {
         return userRepository
                 .findByKeywordUserKeywordId(keywordId)
                 .stream()
@@ -109,7 +116,8 @@ public class UserService {
                 .collect(Collectors.toList());
     }
 
-    public List<UserResponse.LastActivityDTO> getUserInfoInCommunity(Long communityId) {
+    public List<UserResponse.LastActivityDTO>
+    getUserInfoInCommunity(final Long communityId) {
         return userRepository
                 .findByCommunityUserCommunityId(communityId)
                 .stream()

--- a/rest/src/test/java/com/waglewagle/rest/thread/ThreadServiceTest.java
+++ b/rest/src/test/java/com/waglewagle/rest/thread/ThreadServiceTest.java
@@ -1,6 +1,5 @@
 package com.waglewagle.rest.thread;
 
-import com.waglewagle.rest.common.PreResponseDTO;
 import com.waglewagle.rest.community.repository.CommunityRepository;
 import com.waglewagle.rest.community.service.CommunityService;
 import com.waglewagle.rest.keyword.service.KeywordService;
@@ -48,11 +47,10 @@ class ThreadServiceTest {
         Long communityId = createCommunity(userId);
         Long keywordId = createKeyword(userId, communityId);
 
-        Thread thread = createThread(userId, keywordId, "sample thread").getData();
+        ThreadResponse.ThreadDTO threadDTO = createThread(userId, keywordId, "sample thread");
 
-        assertThat(thread).isNotNull();
-        assertThat(thread.getParentThread()).isNull();
-        assertThat(thread.getAuthor().getId()).isEqualTo(userId);
+        assertThat(threadDTO).isNotNull();
+        assertThat(threadDTO.getAuthor().getUserId()).isEqualTo(userId.toString());
 
     }
 
@@ -63,11 +61,11 @@ class ThreadServiceTest {
         Long communityId = createCommunity(userId);
         Long keywordId = createKeyword(userId, communityId);
 
-        Thread thread = createThread(userId, keywordId, "sample thread").getData();
+        ThreadResponse.ThreadDTO threadDTO = createThread(userId, keywordId, "sample thread");
 
-        threadService.deleteThread(userId, thread.getId());
+        threadService.deleteThread(userId, Long.parseLong(threadDTO.getThreadId()));
 
-        Thread deletedThread = threadRepository.findThreadById(thread.getId());
+        Thread deletedThread = threadRepository.findThreadById(Long.parseLong(threadDTO.getThreadId()));
 
         assertThat(deletedThread).isNull();
         assertThat(threadRepository.findAll().size()).isEqualTo(0);
@@ -81,15 +79,15 @@ class ThreadServiceTest {
         Long communityId = createCommunity(userId);
         Long keywordId = createKeyword(userId, communityId);
 
-        Thread thread = createThread(userId, keywordId, "sample thread1").getData();
+        ThreadResponse.ThreadDTO threadDTO = createThread(userId, keywordId, "sample thread1");
         createThread(userId, keywordId, "sample thread2");
         createThread(userId, keywordId, "sample thread3");
         createThread(userId, keywordId, "sample thread4");
-        createChildThread(userId, keywordId, thread.getId(), "sample child thread1");
-        createChildThread(userId, keywordId, thread.getId(), "sample child thread2");
-        createChildThread(userId, keywordId, thread.getId(), "sample child thread3");
+        createChildThread(userId, keywordId, Long.parseLong(threadDTO.getThreadId()), "sample child thread1");
+        createChildThread(userId, keywordId, Long.parseLong(threadDTO.getThreadId()), "sample child thread2");
+        createChildThread(userId, keywordId, Long.parseLong(threadDTO.getThreadId()), "sample child thread3");
 
-        List<ThreadResponse.ThreadDTO> threads = threadService.getThreadsInKeyword(keywordId);
+        List<ThreadResponse.ThreadDTO> threads = threadService.getThreadsInKeyword(keywordId).getData();
 
         assertThat(threads.size()).isEqualTo(4);
         // TODO : 자꾸 자식 쓰레드가 안 읽힌다.
@@ -116,15 +114,24 @@ class ThreadServiceTest {
         return keywordService.createKeyword(userId, communityId, "keyword").getId();
     }
 
-    PreResponseDTO<Thread> createThread(Long userId, Long keywordId, String content) {
-        ThreadRequest.CreateThreadInputDTO createThreadInputDTO = ThreadRequest.CreateThreadInputDTO.from(keywordId, content);
+    ThreadResponse.ThreadDTO
+    createThread(final Long userId,
+                 final Long keywordId,
+                 final String content) {
+        ThreadRequest.CreateDTO
+                createDTO = ThreadRequest.CreateDTO.from(keywordId, content);
 
-        return threadService.creatThread(userId, createThreadInputDTO);
+        return threadService.creatThread(userId, createDTO).getData();
     }
 
-    PreResponseDTO<Thread> createChildThread(Long userId, Long keywordId, Long threadId, String content) {
-        ThreadRequest.CreateThreadInputDTO createThreadInputDTO = ThreadRequest.CreateThreadInputDTO.from(keywordId, threadId, content);
+    ThreadResponse.ThreadDTO
+    createChildThread(final Long userId,
+                      final Long keywordId,
+                      final Long threadId,
+                      final String content) {
+        ThreadRequest.CreateDTO
+                createDTO = ThreadRequest.CreateDTO.from(keywordId, threadId, content);
 
-        return threadService.creatThread(userId, createThreadInputDTO);
+        return threadService.creatThread(userId, createDTO).getData();
     }
 }


### PR DESCRIPTION
# 📄 작업 결과물

1. Validation 로직이 controller에서 service로 이동함.
2. Optional 객체를 사용하여 validation 진행
3. 추후 custom exception을 활용하여 throw되는 exception을 대체할 예정

# 🏗️ 작업 배경

1. validation 로직이 controller에서 진행되면, 같은 transaction 내에서 validation이 진행되지 않는다.
2. 또한, test code를 작성하기에 controller의 관심사가 너무 크다.
3. service layer에서 throw한 exception은 exception handler로 이동하게 될 것이므로, 관심사를 분리할 수 있다.
4. Optional 객체를 활용한 함수형 프로그래밍으로 효과적으로 validation을 진행할 수 있다.
