### PR TITLE
[Refactor] KeywordRepository 'Spring Data JPA + QueryDSL'로 마이그레이션

### DIFF
--- a/rest/src/main/java/com/waglewagle/rest/keyword/repository/KeywordRepository.java
+++ b/rest/src/main/java/com/waglewagle/rest/keyword/repository/KeywordRepository.java
@@ -7,105 +7,17 @@ import com.waglewagle.rest.keyword.data_object.dto.request.KeywordRequest;
 import com.waglewagle.rest.keyword.entity.Keyword;
 import com.waglewagle.rest.keyword.entity.QKeyword;
 import com.waglewagle.rest.keyword.entity.QKeywordUser;
+import com.waglewagle.rest.keyword.repository.custom.KeywordCustomRepository;
 import com.waglewagle.rest.user.entity.QUser;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
 import java.util.List;
 import java.util.Optional;
 
-@Repository
-@RequiredArgsConstructor
-public class KeywordRepository {
-
-    private final EntityManager em;
-    private final JPAQueryFactory jpaQueryFactory;
-
-    public Keyword
-    findOne(final Long keywordId) {
-        return em.find(Keyword.class, keywordId);
-    }
-
-
-    public Optional<Keyword>
-    findById(final Long keywordId) {
-        return Optional
-                .ofNullable(
-                        em
-                                .find(Keyword.class, keywordId)
-                );
-    }
-
-    public List<Keyword>
-    findAllByCommunityId(final Long communityId) {
-        return jpaQueryFactory
-                .selectFrom(QKeyword.keyword1)
-                .distinct()
-                .leftJoin(QKeyword.keyword1.community, QCommunity.community)
-                .leftJoin(QKeyword.keyword1.keywordUsers, QKeywordUser.keywordUser)
-                .fetchJoin()
-                .where(QCommunity.community.id.eq(communityId))
-                .fetch();
-    }
-
-    public List<Keyword>
-    findAssociatedKeywords(final Keyword keyword) {
-
-        return jpaQueryFactory
-                .select(QKeywordUser.keywordUser.keyword)
-                .from(QKeywordUser.keywordUser)
-                .where(QKeywordUser.keywordUser.user.in(
-                        JPAExpressions
-                                .select(new QUser(QKeywordUser.keywordUser.user))
-                                .from(QKeywordUser.keywordUser)
-                                .where(QKeywordUser.keywordUser.keyword.eq(keyword))
-                ))
-                .where(QKeywordUser.keywordUser.keyword.community.eq(keyword.getCommunity()))
-                .fetch(); //TODO: fetch? fetchJoin?
-    }
-
-    public boolean
-    isKeywordDuplicated(final KeywordRequest.CreateDTO createDTO) {
-        return em.createQuery("SELECT k FROM Keyword k WHERE k.keyword = :keywordName AND k.community.id = :communityId", Keyword.class)
-                .setParameter("keywordName", createDTO.getKeywordName())
-                .setParameter("communityId", createDTO.getCommunityId())
-                .getResultList()
-                .size() == 1;
-    }
-
-    public void
-    saveKeyword(final Keyword keyword) {
-        em.persist(keyword);
-//        return keyword;
-    }
-
-    public List<Keyword>
-    getJoinedKeywords(final Long userId,
-                      final Long communityId) {
-        return jpaQueryFactory
-                .select(QKeywordUser.keywordUser.keyword)
-                .from(QKeywordUser.keywordUser)
-                .where(QKeywordUser.keywordUser.user.id.eq(userId))
-                .where(QKeywordUser.keywordUser.community.id.eq(communityId))
-                .fetch();
-    }
-
-    public List<Keyword>
-    findAllByIdList(final List<Long> idList) {
-        return em.createQuery("select distinct k from Keyword k join fetch k.keywordUsers where k.id in :idList ", Keyword.class)
-                .setParameter("idList", idList)
-                .getResultList();
-    }
-
-    @Modifying(clearAutomatically = true)
-    //TODO: 이거 안먹혔다. & jpa (1차?) 캐시는 트랜잭션 단위다? (트랜잭션 끼리 캐시를 공유하지 않는다? / 트랜잭션 마다 캐시를 가진다.)
-    public int
-    deleteAllByIdInBulk(final List<Long> targetIdList) {
-        return (int) jpaQueryFactory.delete(QKeyword.keyword1).where(QKeyword.keyword1.id.in(targetIdList)).execute();
-//        return em.createQuery("DELETE FROM Keyword WHERE Keyword.id IN :targetIdList", Keyword.class)
-//                .setParameter("targetIdList", targetIdList)
-//                .executeUpdate();
-    }
+public interface KeywordRepository extends JpaRepository<Keyword, Long>, KeywordCustomRepository {
 }

--- a/rest/src/main/java/com/waglewagle/rest/keyword/repository/custom/KeywordCustomRepository.java
+++ b/rest/src/main/java/com/waglewagle/rest/keyword/repository/custom/KeywordCustomRepository.java
@@ -1,0 +1,19 @@
+package com.waglewagle.rest.keyword.repository.custom;
+
+import com.waglewagle.rest.keyword.entity.Keyword;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface KeywordCustomRepository {
+
+    List<Keyword> findAssociatedKeywords(final Keyword keyword);
+
+    List<Keyword> findAllFromKeywordUserByUserIdAndCommunityId(final Long userId, final Long communityId);
+
+    int deleteAllByIdInBulk(final List<Long> targetIdList);
+
+    Optional<Keyword> findByKeywordNameAndCommunityId(final String keywordName, final Long communityId);
+
+    List<Keyword> findAllByCommunityIdJoinKeywordUser(final Long communityId);
+}

--- a/rest/src/main/java/com/waglewagle/rest/keyword/repository/custom/KeywordCustomRepositoryImpl.java
+++ b/rest/src/main/java/com/waglewagle/rest/keyword/repository/custom/KeywordCustomRepositoryImpl.java
@@ -1,0 +1,86 @@
+package com.waglewagle.rest.keyword.repository.custom;
+
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.waglewagle.rest.community.entity.QCommunity;
+import com.waglewagle.rest.keyword.entity.Keyword;
+import com.waglewagle.rest.keyword.entity.QKeyword;
+import com.waglewagle.rest.keyword.entity.QKeywordUser;
+import com.waglewagle.rest.user.entity.QUser;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.NonUniqueObjectException;
+import org.hibernate.NonUniqueResultException;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class KeywordCustomRepositoryImpl implements KeywordCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public List<Keyword>
+    findAssociatedKeywords(final Keyword keyword) {
+
+        return jpaQueryFactory
+                .select(QKeywordUser.keywordUser.keyword)
+                .from(QKeywordUser.keywordUser)
+                .where(QKeywordUser.keywordUser.user.in(
+                        JPAExpressions
+                                .select(new QUser(QKeywordUser.keywordUser.user))
+                                .from(QKeywordUser.keywordUser)
+                                .where(QKeywordUser.keywordUser.keyword.eq(keyword))
+                ))
+                .where(QKeywordUser.keywordUser.keyword.community.eq(keyword.getCommunity()))
+                .fetch();
+    }
+
+    public List<Keyword>
+    findAllFromKeywordUserByUserIdAndCommunityId(final Long userId,
+                      final Long communityId) {
+        return jpaQueryFactory
+                .select(QKeywordUser.keywordUser.keyword)
+                .from(QKeywordUser.keywordUser)
+                .where(QKeywordUser.keywordUser.user.id.eq(userId))
+                .where(QKeywordUser.keywordUser.community.id.eq(communityId))
+                .fetch();
+    }
+
+//    @Modifying(clearAutomatically = true)//TODO: 이거 안먹혔다. & jpa (1차?) 캐시는 트랜잭션 단위다? (트랜잭션 끼리 캐시를 공유하지 않는다? / 트랜잭션 마다 캐시를 가진다.)
+    public int
+    deleteAllByIdInBulk(final List<Long> targetIdList) {
+        return (int) jpaQueryFactory.delete(QKeyword.keyword1).where(QKeyword.keyword1.id.in(targetIdList)).execute();
+//        return em.createQuery("DELETE FROM Keyword WHERE Keyword.id IN :targetIdList", Keyword.class)
+//                .setParameter("targetIdList", targetIdList)
+//                .executeUpdate();
+    } //TODO: deleteBatch???
+
+    public Optional<Keyword>
+    findByKeywordNameAndCommunityId(final String keywordName,
+                                    final Long communityId) {
+
+        return Optional
+                .ofNullable(
+                        jpaQueryFactory
+                                .selectFrom(QKeyword.keyword1)
+                                .where(QKeyword.keyword1.keyword.eq(keywordName))
+                                .where(QKeyword.keyword1.community.id.eq(communityId))
+                                .fetchOne());
+    }
+
+    public List<Keyword>
+    findAllByCommunityIdJoinKeywordUser(final Long communityId) {
+        return jpaQueryFactory
+                .selectFrom(QKeyword.keyword1)
+                .distinct()
+//                .leftJoin(QKeyword.keyword1.community, QCommunity.community)
+                .leftJoin(QKeyword.keyword1.keywordUsers, QKeywordUser.keywordUser)
+                .fetchJoin()
+//                .where(QCommunity.community.id.eq(communityId))
+                .where(QKeyword.keyword1.community.id.eq(communityId))
+                .fetch();
+    }
+}

--- a/rest/src/main/java/com/waglewagle/rest/keyword/service/KeywordUserService.java
+++ b/rest/src/main/java/com/waglewagle/rest/keyword/service/KeywordUserService.java
@@ -5,6 +5,7 @@ import com.waglewagle.rest.community.entity.Community;
 import com.waglewagle.rest.community.repository.CommunityRepository;
 import com.waglewagle.rest.keyword.data_object.dto.request.KeywordRequest;
 import com.waglewagle.rest.keyword.entity.Keyword;
+import com.waglewagle.rest.keyword.exception.NoSuchKeywordException;
 import com.waglewagle.rest.keyword.repository.KeywordRepository;
 import com.waglewagle.rest.keyword.repository.KeywordUserRepository;
 import com.waglewagle.rest.user.entity.User;
@@ -13,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -28,8 +30,9 @@ public class KeywordUserService {
     disjoinKeyword(final KeywordRequest.DisjoinDTO disjoinDTO,
                    final Long userId) {
 
-        Keyword keyword = keywordRepository.findOne(disjoinDTO.getKeywordId());
-
+        Keyword keyword = keywordRepository
+                .findById(disjoinDTO.getKeywordId())
+                .orElseThrow(NoSuchKeywordException::new);
         User user = userRepository
                 .findById(userId)
                 .orElseThrow(IllegalArgumentException::new);

--- a/rest/src/main/java/com/waglewagle/rest/thread/repository/ThreadRepository.java
+++ b/rest/src/main/java/com/waglewagle/rest/thread/repository/ThreadRepository.java
@@ -2,6 +2,7 @@ package com.waglewagle.rest.thread.repository;
 
 
 import com.waglewagle.rest.thread.entity.Thread;
+import com.waglewagle.rest.thread.repository.custom.ThreadCustomRepository;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -12,7 +13,7 @@ import java.util.List;
 
 
 @Repository
-public interface ThreadRepository extends JpaRepository<Thread, Long>, com.waglewagle.rest.thread.repository.custom.ThreadCustomRepository {
+public interface ThreadRepository extends JpaRepository<Thread, Long>, ThreadCustomRepository {
 
     void deleteAllByParentThreadId(Long parentThreadId);
 


### PR DESCRIPTION
# 📄 작업 결과물
- `KeywordRepository` 리팩토링


# 🏗️ 작업 배경
- Repository 레이어 코드 일관성이 필요 하였음
- `Optinal`을 기본 반환값으로 사용하는 spring data jpa를 채용

# 💻 작업 내용
- `KeywordRepository`를 'spring data jpa + QueryDSL' 조합으로 마이그레이션


# ➡️ 이후 작업 내용
- `Keyword` 도메인에 대한 코드 점검, 리팩토링, 테스트 코드 작성