### PR TITLE
[refactor] validation 로직 이동 및 exception을 throw하는 방식으로 변경

### DIFF
--- a/rest/src/main/java/com/waglewagle/rest/common/exception/ExceptionMessage.java
+++ b/rest/src/main/java/com/waglewagle/rest/common/exception/ExceptionMessage.java
@@ -1,0 +1,13 @@
+package com.waglewagle.rest.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ExceptionMessage {
+
+    INVALID_INPUT("유효하지 않은 입력입니다.");
+
+    private final String message;
+}

--- a/rest/src/main/java/com/waglewagle/rest/common/exception/InvalidInputException.java
+++ b/rest/src/main/java/com/waglewagle/rest/common/exception/InvalidInputException.java
@@ -1,0 +1,7 @@
+package com.waglewagle.rest.common.exception;
+
+public class InvalidInputException extends RuntimeException {
+    public InvalidInputException() {
+        super(ExceptionMessage.INVALID_INPUT.getMessage());
+    }
+}

--- a/rest/src/main/java/com/waglewagle/rest/community/controller/CommunityUserController.java
+++ b/rest/src/main/java/com/waglewagle/rest/community/controller/CommunityUserController.java
@@ -1,5 +1,6 @@
 package com.waglewagle.rest.community.controller;
 
+import com.waglewagle.rest.common.PreResponseDTO;
 import com.waglewagle.rest.community.data_object.dto.request.CommunityUserRequest;
 import com.waglewagle.rest.community.service.CommunityUserService;
 import lombok.RequiredArgsConstructor;
@@ -21,24 +22,16 @@ public class CommunityUserController {
      * communityId: string
      */
     @PostMapping("")
-    public ResponseEntity<String>
+    public ResponseEntity
     joinCommunity(@RequestBody final CommunityUserRequest.JoinDTO joinDTO,
                   @CookieValue("user_id") final Long userId) {
 
         Long communityId = Long.parseLong(joinDTO.getCommunityId());
+        PreResponseDTO preResponseDTO = communityUserService.joinCommunity(userId, communityId);
 
-        if (communityUserService.isJoined(userId, communityId)) {
-            return new ResponseEntity<>(null, HttpStatus.OK); //TODO: TEMP FOR DEMO
-//             return new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);
-        }
-
-        try {
-            communityUserService.joinCommunity(userId, communityId);
-        } catch (IllegalArgumentException e) {
-            return new ResponseEntity<>(e.getMessage(), HttpStatus.NOT_FOUND);
-        }
-
-        return new ResponseEntity<>(null, HttpStatus.CREATED);
+        return new ResponseEntity<>(
+                preResponseDTO.getData(),
+                preResponseDTO.getHttpStatus());
     }
 
     /**
@@ -51,15 +44,11 @@ public class CommunityUserController {
                                @CookieValue("user_id") final Long userId) {
 
         if (updateProfileDTO.isEmpty()) {
-            return new ResponseEntity(null, HttpStatus.BAD_REQUEST);
+            return new ResponseEntity(HttpStatus.BAD_REQUEST);
         }
-        if (!communityUserService.isJoined(userId, communityId)) {
-            return new ResponseEntity(null, HttpStatus.BAD_REQUEST);
-        }
-
         communityUserService.updateCommunityUserProfile(updateProfileDTO, communityId, userId);
 
-        return new ResponseEntity(null, HttpStatus.OK);
+        return new ResponseEntity(HttpStatus.OK);
     }
 
     @PutMapping("{community_id}/first-visit")
@@ -67,16 +56,9 @@ public class CommunityUserController {
     updateIsFirstVisit(@PathVariable("community_id") final Long communityId,
                        @CookieValue("user_id") final Long userId) {
 
-        if (!communityUserService.isJoined(userId, communityId)) {
-            return new ResponseEntity(null, HttpStatus.BAD_REQUEST);
-        }
-        if (!communityUserService.isFirstVisit(userId, communityId)) {
-            return new ResponseEntity(null, HttpStatus.BAD_REQUEST);
-        }
-
         communityUserService.updateIsFirstVisit(userId, communityId);
 
-        return new ResponseEntity(null, HttpStatus.OK);
+        return new ResponseEntity(HttpStatus.OK);
     }
 
 }

--- a/rest/src/main/java/com/waglewagle/rest/community/exception/AlreadyJoinedCommunityException.java
+++ b/rest/src/main/java/com/waglewagle/rest/community/exception/AlreadyJoinedCommunityException.java
@@ -1,0 +1,9 @@
+package com.waglewagle.rest.community.exception;
+
+import org.springframework.dao.DuplicateKeyException;
+
+public class AlreadyJoinedCommunityException extends DuplicateKeyException {
+    public AlreadyJoinedCommunityException() {
+        super(ExceptionMessage.ALREADY_JOINED_COMMUNITY.getMessage());
+    }
+}

--- a/rest/src/main/java/com/waglewagle/rest/community/exception/ExceptionMessage.java
+++ b/rest/src/main/java/com/waglewagle/rest/community/exception/ExceptionMessage.java
@@ -1,0 +1,15 @@
+package com.waglewagle.rest.community.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ExceptionMessage {
+
+    NO_SUCH_COMMUNITY("커뮤니티를 찾을 수 없습니다."),
+    ALREADY_JOINED_COMMUNITY("이미 가입한 커뮤니티입니다."),
+    UNSUBSCRIBED_COMMUNITY("가입하지 않은 커뮤니티입니다.");
+
+    private final String message;
+}

--- a/rest/src/main/java/com/waglewagle/rest/community/exception/NoSuchCommunityException.java
+++ b/rest/src/main/java/com/waglewagle/rest/community/exception/NoSuchCommunityException.java
@@ -1,0 +1,9 @@
+package com.waglewagle.rest.community.exception;
+
+import java.util.NoSuchElementException;
+
+public class NoSuchCommunityException extends NoSuchElementException {
+    public NoSuchCommunityException() {
+        super(ExceptionMessage.NO_SUCH_COMMUNITY.getMessage());
+    }
+}

--- a/rest/src/main/java/com/waglewagle/rest/community/exception/UnSubscribedCommunityException.java
+++ b/rest/src/main/java/com/waglewagle/rest/community/exception/UnSubscribedCommunityException.java
@@ -1,0 +1,7 @@
+package com.waglewagle.rest.community.exception;
+
+public class UnSubscribedCommunityException extends RuntimeException {
+    public UnSubscribedCommunityException() {
+        super(ExceptionMessage.UNSUBSCRIBED_COMMUNITY.getMessage());
+    }
+}

--- a/rest/src/main/java/com/waglewagle/rest/community/service/CommunityService.java
+++ b/rest/src/main/java/com/waglewagle/rest/community/service/CommunityService.java
@@ -5,6 +5,7 @@ import com.waglewagle.rest.community.data_object.dto.response.CommunityResponse;
 import com.waglewagle.rest.community.entity.Community;
 import com.waglewagle.rest.community.repository.CommunityRepository;
 import com.waglewagle.rest.user.entity.User;
+import com.waglewagle.rest.user.exception.NoSuchUserException;
 import com.waglewagle.rest.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -25,7 +26,6 @@ public class CommunityService {
     @Transactional
     public boolean
     isExistCommunity(final Long communityId) {
-
         return communityRepository.findById(communityId).isPresent();
     }
 
@@ -45,12 +45,11 @@ public class CommunityService {
     public PreResponseDTO<CommunityResponse.CommunityDTO>
     createCommunity(final Long userId,
                     final String title,
-                    final String description) {
+                    final String description) throws NoSuchUserException {
 
-        User user = userRepository.findById(userId).orElse(null);
-        if (user == null) {
-            return new PreResponseDTO<>(null, HttpStatus.FORBIDDEN);
-        }
+        User user = userRepository
+                .findById(userId)
+                .orElseThrow(NoSuchUserException::new);
 
         Community community = Community.from(title, description, user);
         communityRepository.save(community);

--- a/rest/src/main/java/com/waglewagle/rest/community/service/CommunityUserService.java
+++ b/rest/src/main/java/com/waglewagle/rest/community/service/CommunityUserService.java
@@ -1,16 +1,24 @@
 package com.waglewagle.rest.community.service;
 
 
+import com.waglewagle.rest.common.PreResponseDTO;
 import com.waglewagle.rest.community.data_object.dto.request.CommunityUserRequest;
 import com.waglewagle.rest.community.entity.Community;
 import com.waglewagle.rest.community.entity.CommunityUser;
+import com.waglewagle.rest.community.exception.AlreadyJoinedCommunityException;
+import com.waglewagle.rest.community.exception.NoSuchCommunityException;
+import com.waglewagle.rest.community.exception.UnSubscribedCommunityException;
 import com.waglewagle.rest.community.repository.CommunityRepository;
 import com.waglewagle.rest.community.repository.CommunityUserRepository;
 import com.waglewagle.rest.user.entity.User;
+import com.waglewagle.rest.user.exception.NoSuchUserException;
 import com.waglewagle.rest.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -21,27 +29,36 @@ public class CommunityUserService {
     private final UserRepository userRepository;
 
 
-    @Transactional
     public boolean
-    isJoined(final Long userId,
-             final Long communityId) {
-        return communityUserRepository.findByUserIdAndCommunityId(userId, communityId) != null;
+    isJoinedCommunity(final Long userId,
+                      final Long communityId) {
+        return Optional
+                .ofNullable(communityUserRepository
+                        .findByUserIdAndCommunityId(userId, communityId))
+                .isPresent();
     }
 
-
     @Transactional
-    public void
+    public PreResponseDTO
     joinCommunity(final Long userId,
-                  final Long communityId) throws IllegalArgumentException {
+                  final Long communityId)
+            throws
+            NoSuchUserException,
+            NoSuchCommunityException {
+
+        
+        if (isJoinedCommunity(userId, communityId))
+            throw new AlreadyJoinedCommunityException();
 
         User user = userRepository
                 .findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+                .orElseThrow(NoSuchUserException::new);
         Community community = communityRepository
                 .findById(communityId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 커뮤니티입니다."));
+                .orElseThrow(NoSuchCommunityException::new);
 
         communityUserRepository.save(CommunityUser.from(user, community));
+        return new PreResponseDTO<>(null, HttpStatus.CREATED);
     }
 
 
@@ -51,25 +68,20 @@ public class CommunityUserService {
                                final Long communityId,
                                final Long userId) {
 
+        if (!isJoinedCommunity(userId, communityId))
+            throw new UnSubscribedCommunityException();
+
         communityUserRepository
                 .findByUserIdAndCommunityId(userId, communityId)
                 .updateProfile(updateProfileDTO);
     }
 
     @Transactional
-    public boolean
-    isFirstVisit(final Long userId,
-                 final Long communityId) {
-
-        return communityUserRepository
-                .findByUserIdAndCommunityId(userId, communityId)
-                .getIsFirstVisit();
-    }
-
-    @Transactional
     public void
     updateIsFirstVisit(final Long userId,
                        final Long communityId) {
+        if (!isJoinedCommunity(userId, communityId))
+            throw new UnSubscribedCommunityException();
 
         communityUserRepository
                 .findByUserIdAndCommunityId(userId, communityId)

--- a/rest/src/main/java/com/waglewagle/rest/keyword/exception/AlreadyJoinedKeywordException.java
+++ b/rest/src/main/java/com/waglewagle/rest/keyword/exception/AlreadyJoinedKeywordException.java
@@ -1,0 +1,9 @@
+package com.waglewagle.rest.keyword.exception;
+
+import org.springframework.dao.DuplicateKeyException;
+
+public class AlreadyJoinedKeywordException extends DuplicateKeyException {
+    public AlreadyJoinedKeywordException() {
+        super(ExceptionMessage.ALREADY_JOINED_KEYWORD.getMessage());
+    }
+}

--- a/rest/src/main/java/com/waglewagle/rest/keyword/exception/ExceptionMessage.java
+++ b/rest/src/main/java/com/waglewagle/rest/keyword/exception/ExceptionMessage.java
@@ -7,7 +7,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ExceptionMessage {
 
-    NO_SUCH_KEYWORD("키워드를 찾을 수 없습니다.");
+    NO_SUCH_KEYWORD("키워드를 찾을 수 없습니다."),
+    ALREADY_JOINED_KEYWORD("이미 가입한 키워드입니다.");
 
     private final String message;
 }

--- a/rest/src/main/java/com/waglewagle/rest/thread/controller/ThreadController.java
+++ b/rest/src/main/java/com/waglewagle/rest/thread/controller/ThreadController.java
@@ -75,11 +75,6 @@ public class ThreadController {
     public ResponseEntity<List<ThreadResponse.ThreadDTO>>
     getThreadsInKeyword(@RequestParam("keyword-id") final Long keywordId) {
 
-        if (!keywordService.isKeywordExist(keywordId)) {
-            // TODO : Error code
-            return new ResponseEntity(null, HttpStatus.NOT_FOUND);
-        }
-
         PreResponseDTO<List<ThreadResponse.ThreadDTO>>
                 preResponseDTO = threadService.getThreadsInKeyword(keywordId);
 

--- a/rest/src/main/java/com/waglewagle/rest/thread/exception/ExceptionMessage.java
+++ b/rest/src/main/java/com/waglewagle/rest/thread/exception/ExceptionMessage.java
@@ -1,0 +1,14 @@
+package com.waglewagle.rest.thread.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ExceptionMessage {
+
+    NO_SUCH_THREAD("스레드를 찾을 수 없습니다."),
+    IN_VALID_THREAD("유효한 스레드가 아닙니다.");
+
+    private final String message;
+}

--- a/rest/src/main/java/com/waglewagle/rest/thread/exception/InvalidThreadException.java
+++ b/rest/src/main/java/com/waglewagle/rest/thread/exception/InvalidThreadException.java
@@ -1,0 +1,7 @@
+package com.waglewagle.rest.thread.exception;
+
+public class InvalidThreadException extends RuntimeException {
+    public InvalidThreadException() {
+        super(ExceptionMessage.IN_VALID_THREAD.getMessage());
+    }
+}

--- a/rest/src/main/java/com/waglewagle/rest/thread/exception/NoSuchThreadException.java
+++ b/rest/src/main/java/com/waglewagle/rest/thread/exception/NoSuchThreadException.java
@@ -1,0 +1,10 @@
+package com.waglewagle.rest.thread.exception;
+
+import java.util.NoSuchElementException;
+
+public class NoSuchThreadException extends NoSuchElementException {
+
+    public NoSuchThreadException() {
+        super(ExceptionMessage.NO_SUCH_THREAD.getMessage());
+    }
+}

--- a/rest/src/main/java/com/waglewagle/rest/user/controller/UserController.java
+++ b/rest/src/main/java/com/waglewagle/rest/user/controller/UserController.java
@@ -74,15 +74,9 @@ public class UserController {
     public ResponseEntity<String>
     updateLastActivity(@CookieValue("user_id") final Long userId) {
 
-        try {
-            userService.updateLastActivity(userId);
-        } catch (IllegalArgumentException e) {
-            return new ResponseEntity<>(e.getMessage(), HttpStatus.NOT_FOUND);
-        }
+        userService.updateLastActivity(userId);
 
-        return new ResponseEntity<>(
-                null,
-                HttpStatus.OK);
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 
     @GetMapping("keyword")

--- a/rest/src/main/java/com/waglewagle/rest/user/exception/DuplicatedUsernameException.java
+++ b/rest/src/main/java/com/waglewagle/rest/user/exception/DuplicatedUsernameException.java
@@ -1,0 +1,9 @@
+package com.waglewagle.rest.user.exception;
+
+import org.springframework.dao.DuplicateKeyException;
+
+public class DuplicatedUsernameException extends DuplicateKeyException {
+    public DuplicatedUsernameException() {
+        super(ExceptionMessage.DUPLICATED_USERNAME.getMessage());
+    }
+}

--- a/rest/src/main/java/com/waglewagle/rest/user/exception/ExceptionMessage.java
+++ b/rest/src/main/java/com/waglewagle/rest/user/exception/ExceptionMessage.java
@@ -1,0 +1,15 @@
+package com.waglewagle.rest.user.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ExceptionMessage {
+
+    NO_SUCH_USER("유저를 찾을 수 없습니다."),
+    UNAUTHORIZED("권한이 없습니다."),
+    DUPLICATED_USERNAME("이미 사용 중인 username입니다.");
+
+    private final String message;
+}

--- a/rest/src/main/java/com/waglewagle/rest/user/exception/NoSuchUserException.java
+++ b/rest/src/main/java/com/waglewagle/rest/user/exception/NoSuchUserException.java
@@ -1,0 +1,10 @@
+package com.waglewagle.rest.user.exception;
+
+import java.util.NoSuchElementException;
+
+public class NoSuchUserException extends NoSuchElementException {
+
+    public NoSuchUserException() {
+        super(ExceptionMessage.NO_SUCH_USER.getMessage());
+    }
+}

--- a/rest/src/main/java/com/waglewagle/rest/user/exception/UnauthorizedException.java
+++ b/rest/src/main/java/com/waglewagle/rest/user/exception/UnauthorizedException.java
@@ -1,0 +1,9 @@
+package com.waglewagle.rest.user.exception;
+
+public class UnauthorizedException extends RuntimeException {
+    public UnauthorizedException() {
+        super(ExceptionMessage.UNAUTHORIZED.getMessage());
+    }
+
+}
+

--- a/rest/src/main/java/com/waglewagle/rest/user/repository/custom/UserCustomRepositoryImpl.java
+++ b/rest/src/main/java/com/waglewagle/rest/user/repository/custom/UserCustomRepositoryImpl.java
@@ -26,6 +26,7 @@ public class UserCustomRepositoryImpl implements UserCustomRepository {
     @Transactional
     public Long
     findOrSaveUsername(final String username) {
+
         User user = jpqlQueryFactory
                 .select(QUser.user)
                 .from(QUser.user)
@@ -46,6 +47,7 @@ public class UserCustomRepositoryImpl implements UserCustomRepository {
 
     public List<User>
     findByKeywordUserKeywordId(final Long keywordId) {
+
         return jpqlQueryFactory
                 .select(keywordUser.user)
                 .from(keywordUser)
@@ -56,6 +58,7 @@ public class UserCustomRepositoryImpl implements UserCustomRepository {
 
     public List<User>
     findByCommunityUserCommunityId(final Long communityId) {
+        
         return jpqlQueryFactory
                 .select(communityUser.user)
                 .from(communityUser)

--- a/rest/src/main/resources/logback-spring.xml
+++ b/rest/src/main/resources/logback-spring.xml
@@ -67,13 +67,15 @@
     </appender>
 
     <root level="INFO">
-        <appender-ref ref="INFO_LOG" />
-        <appender-ref ref="WARN_LOG" />
+        <appender-ref ref="STDOUT" />
+<!--        <appender-ref ref="INFO_LOG" />-->
+<!--        <appender-ref ref="WARN_LOG" />-->
     </root>
 
     <logger name="org.hibernate.SQL" additivity="false">
         <level value = "DEBUG" />
-        <appender-ref ref="DEBUG_LOG" />
+        <appender-ref ref="STDOUT" />
+<!--        <appender-ref ref="DEBUG_LOG" />-->
     </logger>
 
 </configuration>


### PR DESCRIPTION
# 📄 작업 결과물

1. 각 도메인에 대하여 Exception 추가
2. 각 도메인에 대하여 enum ExceptionMessage 추가
3. validation 로직 controller에서 service layer로 이동

# 🏗️ 작업 배경

1. transaction을 고려하여 validation 로직 이동.
2. 예외 처리에 대한 관심사가 service layer에 있는 것은, 너무 많은 관심사로 판단.
3. exception을 일괄적으로 관리하기 위해서는 enum으로 message를 관리하고, custom exception을 만드는 것이 좋다고 판단.
  - custom exception이 아니라면, 정말 internal server error라고 판단.

# 💻 작업 내용

1. 생성된 Exception
  - common
    - InvalidInputException
  - Keyword
    - AlreadyJoinedKeywordException
    - NoSuchKeywordException
  - User
    - DuplicatedUsernameException
    - NoSuchUserException
    - UnauthorizedException
  - Thread
    - InvalidThreadException
    - NoSuchThreadException
  - Community
    - AlreadyJoinedCommunityException
    - NoSuchCommunityException
    - UnSubscribedCommunityException

# ➡️ 이후 작업 내용

1. 테스트 코드 작성 및 keyword 도메인 비즈니스 로직 점검
