### PR TITLE
[hotfix] validation 로직이 거꾸로 되어 에러가 발생하던 문제 해결

### DIFF
--- a/rest/src/main/java/com/waglewagle/rest/keyword/service/KeywordService.java
+++ b/rest/src/main/java/com/waglewagle/rest/keyword/service/KeywordService.java
@@ -188,9 +188,7 @@ public class KeywordService {
 
         communityUserRepository
                 .findOptionalByUserIdAndCommunityId(userId, communityId)
-                .ifPresent(__ -> {
-                    throw new UnSubscribedCommunityException();
-                });
+                .orElseThrow(UnSubscribedCommunityException::new);
 
         List<KeywordResponse.KeywordDTO>
                 keywordDTOS = keywordRepository


### PR DESCRIPTION
# 📄 작업 결과물

내가 참여한 커뮤니티를 조회하던 과정에서 있던 validation 로직 오류 수정

# 🏗️ 작업 배경

내가 참여한 커뮤니티를 검증하는 과정에서 논리적 오류가 있어서 정상적인 상황에서 exception이 발생하는 버그가 있었음

# 💻 작업 내용

내가 참여한 커뮤니티를 조회하던 과정에서 있던 validation 로직 오류 수정