### PR TITLE
[fix] useRelatedKeywordList 버그 해결

### DIFF
--- a/frontend/hooks/keyword/useRelatedKeywordList.tsx
+++ b/frontend/hooks/keyword/useRelatedKeywordList.tsx
@@ -3,11 +3,14 @@ import { apis } from '@apis/index';
 import { REACT_QUERY_KEY } from '@constants/constants';
 import { useQuery } from '@tanstack/react-query';
 
-const useRelatedKeywordList = (prevKeyword: MyKeywordData) => {
+// 이전 입력 키워드가 없는 상태로 useRelatedKeywordList가 호출될 수 있음.
+// Tanstack Query 내부에서 enabled 설정을 통해 문제를 해결함.
+// useQuery에서 전달해주는 인자에 대한 타입 추론을 제대로 못해서 non-null assertion 사용함.
+const useRelatedKeywordList = (prevKeyword?: MyKeywordData) => {
   const getRelatedKeywordList = async () => {
     const { data } = await apis.keyword.getKeywordAssociations(
-      prevKeyword.keywordId,
-    ); // Tanstack Query 내부에서 enabled 설정을 했기 때문에 non-null assertion 사용함
+      prevKeyword!.keywordId,
+    );
     return data;
   };
 


### PR DESCRIPTION
- prevKeywordData가 optional로 오기 때문에 발생하던 에러
- useQuery 내부에서 enabled를 설정하여 해결함.