### PR TITLE
[fix] 키워드가 존재하지 않아도 생성할 수 없던 버그 수정

### DIFF
--- a/rest/src/main/java/com/waglewagle/rest/keyword/service/KeywordService.java
+++ b/rest/src/main/java/com/waglewagle/rest/keyword/service/KeywordService.java
@@ -110,11 +110,10 @@ public class KeywordService {
             NoSuchUserException,
             NoSuchCommunityException {
 
-        Optional
-                .ofNullable(
-                        keywordRepository
-                                .findByKeywordNameAndCommunityId(keywordName, communityId))
+        keywordRepository
+                .findByKeywordNameAndCommunityId(keywordName, communityId)
                 .ifPresent((__) -> {
+                    System.out.println();
                     throw new DuplicatedKeywordException();
                 });
 


### PR DESCRIPTION
# 📄 작업 결과물

키워드가 존재하지 않아도 생성할 수 없던 버그 수정

# 🏗️ 작업 배경

커뮤니티에 키워드가 존재하지 않아도 생성할 수 없었음

# 💻 작업 내용

Optional 객체에 대한 Optional 객체를 만들어 validation을 진행하던 버그 수정