### PR TITLE
[feat] 내가 참여한 커뮤니티 멤버 수 API

### DIFF
--- a/rest/src/main/java/com/waglewagle/rest/community/data_object/dto/response/CommunityResponse.java
+++ b/rest/src/main/java/com/waglewagle/rest/community/data_object/dto/response/CommunityResponse.java
@@ -13,6 +13,7 @@ public class CommunityResponse {
         private String communityId;
         private String title;
         private String description;
+        private int memberCount = 0;
 
         public static CommunityDTO of(final Community community) {
             CommunityDTO communityDTO = new CommunityDTO();
@@ -20,6 +21,10 @@ public class CommunityResponse {
             communityDTO.title = community.getTitle();
             communityDTO.description = community.getSummary();
             return communityDTO;
+        }
+
+        public void addMemberCount() {
+            memberCount++;
         }
     }
 }

--- a/rest/src/main/java/com/waglewagle/rest/community/repository/custom/CommunityUserCustomRepository.java
+++ b/rest/src/main/java/com/waglewagle/rest/community/repository/custom/CommunityUserCustomRepository.java
@@ -2,6 +2,7 @@ package com.waglewagle.rest.community.repository.custom;
 
 import com.waglewagle.rest.community.entity.CommunityUser;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CommunityUserCustomRepository {
@@ -9,4 +10,6 @@ public interface CommunityUserCustomRepository {
     CommunityUser findByUserIdAndCommunityId(Long userId, Long communityId);
 
     Optional<CommunityUser> findOptionalByUserIdAndCommunityId(Long userId, Long communityId);
+
+    List<CommunityUser> findAllByCommunityIds(final List<Long> communityIds);
 }

--- a/rest/src/main/java/com/waglewagle/rest/community/repository/custom/CommunityUserCustomRepositoryImpl.java
+++ b/rest/src/main/java/com/waglewagle/rest/community/repository/custom/CommunityUserCustomRepositoryImpl.java
@@ -6,6 +6,7 @@ import com.waglewagle.rest.community.entity.QCommunityUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 
@@ -40,5 +41,15 @@ public class CommunityUserCustomRepositoryImpl implements CommunityUserCustomRep
                         .where(QCommunityUser.communityUser.community.id.eq(communityId))
                         .fetchOne()
         );
+    }
+
+    public List<CommunityUser>
+    findAllByCommunityIds(final List<Long> communityIds) {
+        return jpqlQueryFactory
+                .select(QCommunityUser.communityUser)
+                .from(QCommunityUser.communityUser)
+                .where(QCommunityUser.communityUser.community.id.in(communityIds))
+                .fetch();
+
     }
 }

--- a/rest/src/main/java/com/waglewagle/rest/community/service/CommunityService.java
+++ b/rest/src/main/java/com/waglewagle/rest/community/service/CommunityService.java
@@ -48,7 +48,7 @@ public class CommunityService {
                 .findAllByCommunityIds(communityIds);
 
         HashMap<Long, CommunityResponse.CommunityDTO> idToDTO = new HashMap<>();
-        
+
         communityDTOS.forEach(communityDTO -> {
             idToDTO.put(Long.parseLong(communityDTO.getCommunityId()), communityDTO);
         });
@@ -73,6 +73,7 @@ public class CommunityService {
                 .orElseThrow(NoSuchUserException::new);
 
         Community community = Community.from(title, description, user);
+        communityUserRepository.save(CommunityUser.from(user, community));
         communityRepository.save(community);
 
         return new PreResponseDTO<>(

--- a/rest/src/main/java/com/waglewagle/rest/community/service/CommunityService.java
+++ b/rest/src/main/java/com/waglewagle/rest/community/service/CommunityService.java
@@ -3,7 +3,9 @@ package com.waglewagle.rest.community.service;
 import com.waglewagle.rest.common.PreResponseDTO;
 import com.waglewagle.rest.community.data_object.dto.response.CommunityResponse;
 import com.waglewagle.rest.community.entity.Community;
+import com.waglewagle.rest.community.entity.CommunityUser;
 import com.waglewagle.rest.community.repository.CommunityRepository;
+import com.waglewagle.rest.community.repository.CommunityUserRepository;
 import com.waglewagle.rest.user.entity.User;
 import com.waglewagle.rest.user.exception.NoSuchUserException;
 import com.waglewagle.rest.user.repository.UserRepository;
@@ -12,6 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -20,17 +23,41 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class CommunityService {
 
+    private final CommunityUserRepository communityUserRepository;
     private final CommunityRepository communityRepository;
     private final UserRepository userRepository;
-    
+
+
     @Transactional
     public PreResponseDTO<List<CommunityResponse.CommunityDTO>>
     getJoinedCommunities(final Long userId) {
-        return new PreResponseDTO<>(communityRepository
+        List<CommunityResponse.CommunityDTO>
+                communityDTOS = communityRepository
                 .getJoinedCommunities(userId)
                 .stream()
                 .map(CommunityResponse.CommunityDTO::of)
-                .collect(Collectors.toList()),
+                .collect(Collectors.toList());
+
+        List<Long> communityIds = communityDTOS
+                .stream()
+                .map(CommunityResponse.CommunityDTO::getCommunityId)
+                .map(Long::parseLong)
+                .collect(Collectors.toList());
+
+        List<CommunityUser> communityUsers = communityUserRepository
+                .findAllByCommunityIds(communityIds);
+
+        HashMap<Long, CommunityResponse.CommunityDTO> idToDTO = new HashMap<>();
+        
+        communityDTOS.forEach(communityDTO -> {
+            idToDTO.put(Long.parseLong(communityDTO.getCommunityId()), communityDTO);
+        });
+        communityUsers.forEach(communityUser -> {
+            idToDTO.get(communityUser.getCommunity().getId()).addMemberCount();
+        });
+
+        return new PreResponseDTO<>(
+                communityDTOS,
                 HttpStatus.OK);
 
     }


### PR DESCRIPTION
# 📄 작업 결과물

- 내가 참여한 커뮤니티 API 멤버 수 필드 추가

# 🏗️ 작업 배경

- 내가 참여한 커뮤니티의 멤버 수를 알 수 없었음

# 💻 작업 내용

- 내가 참여한 커뮤니티의 id들을 기준으로 하여 communityUser entitiy를 가져오는 메서드 생성
- 해당 메서드를 모두 communityDTO와 mapping하여 반환